### PR TITLE
Initial project setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.coverage
+*-coverage.txt
+*.egg-info
+__pycache__
+.eggs/
+.tox/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: MIT
+---
+language: python
+python:
+  - 3.6
+  - 3.7
+  - 3.8
+  - 3.9-dev
+
+install:
+  - pip install tox tox-travis coveralls
+
+script:
+  - COVERALLS_PARALLEL=true COVERALLS_CMD=coveralls tox
+
+notifications:
+  webhooks: https://coveralls.io/webhook

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,3 @@
+# List of Authors and Contributors
+
+* Jiří Kučera <sanczes AT gmail com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Change Log

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+include LICENSE
+include *.md
+include pyproject.toml
+exclude .*
+exclude tox.ini
+prune stubs
+prune tests

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Coverage Status](https://coveralls.io/repos/github/linux-system-roles/tox-lsr/badge.svg?branch=main)](https://coveralls.io/github/linux-system-roles/tox-lsr?branch=main)
+
 # Linux System Roles Plugin for `tox`
 
 This plugin for `tox` provides default settings used for testing Linux system

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: MIT
+
+[build-system]
+requires = ["setuptools >=40.9.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.black]
+line-length = 79
+
+[tool.isort]
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+ensure_newline_before_comments = true
+line_length = 79
+
+[tool.pylint.format]
+max-line-length = 79
+
+[tool.pylint."message control"]
+disable = "R0205"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: MIT
+
+[metadata]
+name = tox-lsr
+version = attr: tox_lsr.version.__version__
+url = https://github.com/linux-system-roles/tox-lsr
+project_urls =
+    Bug Reports = https://github.com/linux-system-roles/tox-lsr/issues
+    Source = https://github.com/linux-system-roles/tox-lsr
+author = Linux System Roles Team
+author_email = systemroles@lists.fedorahosted.org
+classifiers =
+    Development Status :: 1 - Planning
+    Environment :: Console
+    Environment :: Plugins
+    Framework :: tox
+    Intended Audience :: Developers
+    License :: OSI Approved :: MIT License
+    Operating System :: POSIX :: Linux
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Topic :: Software Development :: Testing
+license = MIT
+license_file = LICENSE
+description = A tox plugin for testing Linux system roles
+long_description = file: README.md
+long_description_content_type = text/markdown
+keywords =
+    plugin
+    tox
+    testing
+platforms =
+    linux
+
+[options]
+zip_safe = False
+setup_requires =
+    setuptools >=40.9.0
+install_requires =
+    tox
+python_requires = >=3.5, <4
+include_package_data = True
+packages = find:
+package_dir =
+    = src
+
+[options.extras_require]
+dev =
+    check-manifest
+test =
+    coverage
+
+[options.entry_points]
+tox =
+    lsr = tox_lsr.hooks
+
+[options.packages.find]
+where = src
+
+[bdist_wheel]
+universal = True
+
+[check]
+metadata = True
+strict = True
+
+[sdist]
+formats = zip, gztar
+
+[flake8]
+filename = *.py,*.pyi
+ignore = E302,E704,H301,H304,H306
+select = E,F,W,C,G,H
+enable-extensions = G,H
+max-line-length = 79
+max-doc-length = 79
+show-source = True
+statistics = True
+doctests = True
+max-complexity = 15
+
+[mypy]
+mypy_path = stubs
+disallow_any_expr = True
+disallow_any_decorated = True
+disallow_any_explicit = True
+disallow_any_generics = True
+disallow_subclassing_any = True
+disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = True
+no_implicit_optional = True
+warn_redundant_casts = True
+warn_unused_ignores = True
+warn_return_any = True
+warn_unreachable = True
+strict_equality = True
+warn_incomplete_stub = True
+warn_unused_configs = True
+
+[pydocstyle]
+match = .*\.py[i]?
+ignore = D202

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,9 @@
+#!/usr/bin/python3
+#                                                         -*- coding: utf-8 -*-
+# SPDX-License-Identifier: MIT
+#
+"""Setup for tox-lsr."""
+
+from setuptools import setup
+
+setup()

--- a/src/tox_lsr/__init__.py
+++ b/src/tox_lsr/__init__.py
@@ -1,0 +1,6 @@
+#                                                         -*- coding: utf-8 -*-
+# SPDX-License-Identifier: MIT
+#
+"""Module that provides tox_lsr plugin."""
+
+from .version import __version__  # noqa: F401

--- a/src/tox_lsr/hooks.py
+++ b/src/tox_lsr/hooks.py
@@ -1,0 +1,16 @@
+#                                                         -*- coding: utf-8 -*-
+# SPDX-License-Identifier: MIT
+#
+"""Install tox-lsr hooks to tox."""
+
+from tox import hookimpl
+from tox.config import Config
+
+
+# Run this hook *after* any other tox_configure hook, especially the tox-travis
+# one.
+@hookimpl(trylast=True)
+def tox_configure(config: Config) -> None:
+    """Adjust tox configuration right after it is loaded."""
+
+    config.envlist.sort()

--- a/src/tox_lsr/version.py
+++ b/src/tox_lsr/version.py
@@ -1,0 +1,6 @@
+#                                                         -*- coding: utf-8 -*-
+# SPDX-License-Identifier: MIT
+#
+"""Holds tox-lsr plugin version."""
+
+__version__ = "0.0.1"

--- a/stubs/tox/__init__.pyi
+++ b/stubs/tox/__init__.pyi
@@ -1,0 +1,12 @@
+#                                                         -*- coding: utf-8 -*-
+# SPDX-License-Identifier: MIT
+#
+"""Type annotations for tox."""
+
+from typing import Callable, TypeVar
+
+from tox.config import Config
+
+_HFT = TypeVar("_HFT", bound=Callable[[Config], None])
+
+def hookimpl(trylast: bool = False) -> Callable[[_HFT], _HFT]: ...

--- a/stubs/tox/config/__init__.pyi
+++ b/stubs/tox/config/__init__.pyi
@@ -1,0 +1,12 @@
+#                                                         -*- coding: utf-8 -*-
+# SPDX-License-Identifier: MIT
+#
+"""Type annotations for tox.config."""
+
+from typing import List
+
+from py import iniconfig
+
+class Config:  # noqa: H238
+    _cfg: iniconfig.IniConfig
+    envlist: List[str]

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,4 @@
+#                                                         -*- coding: utf-8 -*-
+# SPDX-License-Identifier: MIT
+#
+"""Module with unit tests for tox_lsr plugin."""

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -1,0 +1,22 @@
+#                                                         -*- coding: utf-8 -*-
+# SPDX-License-Identifier: MIT
+#
+"""Tests for tox_lsr hooks."""
+
+import unittest2
+
+from tox_lsr.hooks import tox_configure
+
+from .utils import MockConfig
+
+
+class HooksTestCase(unittest2.TestCase):
+    def setUp(self):
+        self.__envlist_unsorted = ["envC", "envB", "envA"]
+        self.__envlist_sorted = ["envA", "envB", "envC"]
+
+    def test_tox_configure_sorts_envlist(self):
+        config = MockConfig(envlist=self.__envlist_unsorted)
+
+        tox_configure(config)
+        self.assertEqual(config.envlist, self.__envlist_sorted)

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -1,0 +1,13 @@
+#                                                         -*- coding: utf-8 -*-
+# SPDX-License-Identifier: MIT
+#
+"""Test for version presence."""
+
+import unittest2
+
+from tox_lsr import __version__
+
+
+class VersionTestCase(unittest2.TestCase):
+    def test_version(self):
+        self.assertIsInstance(__version__, str)

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -1,0 +1,14 @@
+#                                                         -*- coding: utf-8 -*-
+# SPDX-License-Identifier: MIT
+#
+"""Test utilities."""
+
+
+class MockConfig(object):
+    __slots__ = ("envlist",)
+
+    def __init__(self, envlist=None):
+        if envlist is None:
+            self.envlist = []
+        else:
+            self.envlist = envlist[:]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: MIT
+
+[tox]
+envlist =
+    py{36,37,38,39},
+    black, isort, pylint, flake8, mypy, bandit, pydocstyle
+skip_missing_interpreters = True
+skipsdist = True
+
+[testenv]
+passenv = *
+setenv =
+    PYTHONPATH=src
+skip_install = True
+description =
+    {envname}: Run unit tests for {envname}
+deps =
+    pip >= 19.2
+    safety
+    tox
+    unittest2
+    pytest
+    pytest-cov
+    coveralls
+commands =
+    safety check --full-report
+    pytest --cov=tox_lsr --cov-report=term-missing tests
+    {env:COVERALLS_CMD:coveralls --output={envname}-coverage.txt}
+
+[linters]
+envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:linters}
+basepython = python3.6
+
+[testenv:black]
+envdir = {[linters]envdir}
+basepython = {[linters]basepython}
+description =
+    {envname}: Run formatting checks
+deps =
+    black
+commands =
+    black --check --diff .
+
+[testenv:isort]
+envdir = {[linters]envdir}
+basepython = {[linters]basepython}
+description =
+    {envname}: Run import order checks
+deps =
+    isort
+commands =
+    isort --diff -c .
+
+[testenv:pylint]
+envdir = {[linters]envdir}
+setenv =
+    PYTHONPATH=src
+basepython = {[linters]basepython}
+description =
+    {envname}: Run static code checks
+deps =
+    tox
+    unittest2
+    pylint
+commands =
+    pylint setup.py src/tox_lsr
+    pylint -d C0115,C0116,C0321,E0611,R0903,W0613 \
+           stubs/tox/__init__.pyi stubs/tox/config/__init__.pyi
+    pylint -d C0115,C0116,R0903 tests/unit
+
+[testenv:flake8]
+envdir = {[linters]envdir}
+basepython = {[linters]basepython}
+description =
+    {envname}: Run style checks
+deps =
+    flake8
+    flake8-logging-format
+    hacking
+commands =
+    flake8
+
+[testenv:mypy]
+envdir = {[linters]envdir}
+basepython = {[linters]basepython}
+description =
+    {envname}: Run type checks
+deps =
+    tox
+    mypy
+commands =
+    mypy src/tox_lsr
+
+[testenv:bandit]
+envdir = {[linters]envdir}
+basepython = {[linters]basepython}
+description =
+    {envname}: Run security analyzer
+deps =
+    bandit
+commands =
+    bandit -vlir setup.py src/tox_lsr stubs tests/unit
+
+[testenv:pydocstyle]
+envdir = {[linters]envdir}
+basepython = {[linters]basepython}
+description =
+    {envname}: Run doc strings checks
+deps =
+    pydocstyle
+commands =
+    pydocstyle setup.py src/tox_lsr
+    pydocstyle --add-ignore=D101,D102,D103,D107 stubs tests/unit
+
+[travis]
+python =
+    3.6: py36, black, isort, pylint, flake8, mypy, bandit, pydocstyle


### PR DESCRIPTION
Minimal skeleton of the project to make linters happy. To prevent shooting to our legs, we use `mypy` with dynamic typing disallowed (i.e. no `Any` in type signatures). `stubs` is a directory with annotations that are not yet present in `mypy` (annotations in `stubs` are incomplete and they cover only needs of this project).