### PR TITLE
handle skip_missing_interpreters correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,15 @@ roles via `tox`. The default settings can be overridden by role developer in
 
 For local development, if you have already installed `tox` and `pip`:
 ```
-pip install --user git+https://github.com/linux-system-roles/tox-lsr@master
+pip install --user git+https://github.com/linux-system-roles/tox-lsr@main
 ```
 This will install `tox-lsr` in your `~/.local` directory where tox should find
-it.
+it.  If you want to use a release tagged version:
+```
+pip install --user git+https://github.com/linux-system-roles/tox-lsr@0.0.4
+```
+Look at https://github.com/linux-system-roles/tox-lsr/releases for the list of
+releases and tags.
 
 To confirm that you have it and that `tox` can use it:
 ```
@@ -59,6 +64,20 @@ If the plugin is not enabled, you would only see testenv definitions in your
 ## Configuration
 
 There are several ways to append to and override the default configuration.
+
+### Tox command line arguments
+
+All of the usual tox command line arguments work as you would expect.  The
+information returned is a result of merging your local tox.ini with the default,
+so flags like `-l` will return the default environments, `-e` can use the
+default environments, `--showconfig` will show the full merged config, etc.
+However, the `--skip-missing-interpreters` argument is ignored.  If you want to
+explicitly set this, you must add it to your local tox.ini:
+```
+[tox]
+skip_missing_interpreters = false
+```
+
 
 ### Standard tox.ini configuration
 

--- a/src/tox_lsr/hooks.py
+++ b/src/tox_lsr/hooks.py
@@ -186,6 +186,18 @@ def merge_config(config, default_config):
         # set in config if not set and it's set in default
         if propname in def_tox_sec and propname not in tox_sec:
             setattr(config, propname, getattr(default_config, propname))
+    # handle skip_missing_interpreters specially because
+    # it is stored in config.option
+    if (
+        "skip_missing_interpreters" not in tox_sec
+        and "skip_missing_interpreters" in def_tox_sec
+    ):
+        default_config.option.skip_missing_interpreters = def_tox_sec[
+            "skip_missing_interpreters"
+        ]
+        config.option.skip_missing_interpreters = (
+            default_config.option.skip_missing_interpreters
+        )
     # merge the top level config properties that are set implicitly
     if hasattr(config, "envlist_explicit") and not config.envlist_explicit:
         config.envlist_default = list(


### PR DESCRIPTION
skip_missing_interpreters requires special handling because tox
does not store it in the `config` object, it stores it in the
`config.option` object.  Unfortunately, the command line option
`--skip-missing-interpreters` is now ignored because the plugin
has no way to tell if `config.option.skip_missing_interpreters`
was set on the command line or in the config.  If you want to
use this, you must set it in your local tox.ini.