### PR TITLE
molecule: remove ansible-lint, add jmespath

### DIFF
--- a/src/tox_lsr/config_files/tox-default.ini
+++ b/src/tox_lsr/config_files/tox-default.ini
@@ -162,7 +162,7 @@ commands = {[coveralls]commands}
 changedir = {toxinidir}
 deps =
     {env:LSR_ANSIBLE_DEP:ansible}
-    ansible-lint==4.3.5
+    jmespath
     {env:LSR_MOLECULE_DRIVER:docker}{env:LSR_MOLECULE_DRIVER_VERSION:}
     molecule<3
     selinux

--- a/tests/fixtures/test_tox_merge_ini/result.ini
+++ b/tests/fixtures/test_tox_merge_ini/result.ini
@@ -138,7 +138,7 @@ commands = {[coveralls]commands}
 [molecule_common]
 changedir = {toxinidir}
 deps = {env:LSR_ANSIBLE_DEP:ansible}
-	ansible-lint==4.3.5
+	jmespath
 	{env:LSR_MOLECULE_DRIVER:docker}{env:LSR_MOLECULE_DRIVER_VERSION:}
 	molecule<3
 	selinux


### PR DESCRIPTION
molecule
- remove the dependency on ansible-lint - linting is now done
  outside of molecule
- add jmespath for playbooks that use json_query