### PR TITLE
lock role2collection to a specific version

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,12 @@ environment variables:
   yamllint
 * `RUN_ANSIBLE_LINT_EXTRA_ARGS` - extra command line arguments to provide to
   ansible-lint
+* `LSR_ROLE2COLL_VERSION` - a tag/commit of the lsr_role2collection script to
+  use for the collection tox test.  The default is the latest stable version.
+* `LSR_ROLE2COLL_NAMESPACE` - namespace to use for the lsr_role2collection
+  script.  The default is `fedora`.
+* `LSR_ROLE2COLL_NAME` - collection name to use for the lsr_role2collection
+  script.  The default is `linux_system_roles`.
 
 These environment variables have been removed:
 * `RUN_PYLINT_INCLUDE` - use `RUN_PYLINT_EXTRA_ARGS`

--- a/src/tox_lsr/config_files/tox-default.ini
+++ b/src/tox_lsr/config_files/tox-default.ini
@@ -25,6 +25,9 @@ setenv =
     LSR_CONFIGDIR = {lsr_configdir}
     LSR_TOX_ENV_NAME = {envname}
     LSR_TOX_ENV_DIR = {envdir}
+    LSR_ROLE2COLL_VERSION = 1.0.0
+    LSR_ROLE2COLL_NAMESPACE = fedora
+    LSR_ROLE2COLL_NAME = linux_system_roles
 deps =
     py{26,27,36,37,38}: pytest-cov
     py{27,36,37,38}: pytest>=3.5.1
@@ -220,7 +223,7 @@ deps =
     ansible
     jmespath
 commands =
-    bash {lsr_scriptdir}/runcollection.sh {toxworkdir} master
+    bash {lsr_scriptdir}/runcollection.sh {toxworkdir} {env:LSR_ROLE2COLL_VERSION:master}
 
 [testenv:custom]
 changedir = {toxinidir}


### PR DESCRIPTION
lock the lsr_role2collection script to a specific version.  This
will allow us to change the script without immediately breaking
CI.  Introduce env. vars. for the script version, namespace, and
collection name.