### PR TITLE
molecule v3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ usage: tox [--lsr-enable] [--version] [-h] [--help-ini] [-v] [-q]
 ```
 This shows that the `--lsr-enable` flag is available.
 
+### Molecule and Ansible Version Support
+
+tox-lsr 2.0 and later use molecule v3, which support Ansible 2.8 and later.  If
+for some reason you need to support Ansible 2.7 or earlier, use tox-lsr 1.x.
+
 ## Example tox.ini
 
 The following is an example of a `tox.ini` from the kernel_settings role:
@@ -78,7 +83,6 @@ explicitly set this, you must add it to your local tox.ini:
 [tox]
 skip_missing_interpreters = false
 ```
-
 
 ### Standard tox.ini configuration
 
@@ -257,12 +261,19 @@ environment variables we used in the old scripts are carried over:
 * `LSR_EXTRA_PACKAGES` - set in `.github/workflows/tox.yml` - list of extra
   packages to install in the CI environment (typically an Ubuntu variant)
 * `LSR_ANSIBLES` - set in `.github/workflows/tox.yml` - ansible versions to test
-  molecule against
+  molecule against in the form that is used with pip e.g. use
+  `LSR_ANSIBLES='ansible==2.8.* ansible==2.9.*'` to use ansible 2.8 and ansible
+  2.9.  Only ansible 2.8 and higher are supported. tox-lsr 2.0 uses molecule v3,
+  which does not work with ansible 2.7 or earlier.
 * `LSR_MSCENARIOS` - set in `.github/workflows/tox.yml` - molecule scenarios to
   test
-* `LSR_MOLECULE_DOCKER_VERSION` - use this if you want to override the version
-  of the `docker` pypi package - otherwise, the correct version will be
-  auto-detected
+* `LSR_MOLECULE_DRIVER` - default `docker` - The molecule driver to use.  If you
+  want to use `podman`, use `LSR_MOLECULE_DRIVER=podman`
+* `LSR_MOLECULE_DRIVER_VERSION` - default empty - use this if you want to
+  override the version of the molecule driver pypi package - otherwise, the
+  correct version will be auto-detected.  E.g.
+  `LSR_MOLECULE_DRIVER=podman LSR_MOLECULE_DRIVER_VERSION='<4.4'` will evaluate
+  to something like `pip install podman<4.4`
 * `LSR_PUBLISH_COVERAGE` - If the variable is unset or empty (the default), no
   coverage is published.  Other valid values for the variable are:
     * `strict` - the reporting is performed in strict mode, so situations like

--- a/src/tox_lsr/config_files/tox-default.ini
+++ b/src/tox_lsr/config_files/tox-default.ini
@@ -167,7 +167,8 @@ deps =
     {env:LSR_ANSIBLE_DEP:ansible}
     jmespath
     {env:LSR_MOLECULE_DRIVER:docker}{env:LSR_MOLECULE_DRIVER_VERSION:}
-    molecule<3
+    molecule==3.*
+    molecule[{env:LSR_MOLECULE_DRIVER:docker}]
     selinux
     wcwidth==0.1.9;python_version=="3.6"
     -rmolecule_extra_requirements.txt
@@ -180,22 +181,6 @@ deps =
 commands =
     bash {[molecule_common]runsyspycmd} molecule --version
     bash {[molecule_common]runsyspycmd} ansible --version
-
-[testenv:molecule_lint]
-changedir = {[molecule_common]changedir}
-deps =
-    {[molecule_common]deps}
-commands =
-    bash {[molecule_common]runsyspycmd} \
-         molecule lint -s {env:LSR_MSCENARIO:default} {posargs}
-
-[testenv:molecule_syntax]
-changedir = {[molecule_common]changedir}
-deps =
-    {[molecule_common]deps}
-commands =
-    bash {[molecule_common]runsyspycmd} \
-         molecule syntax -s {env:LSR_MSCENARIO:default} {posargs}
 
 [testenv:molecule_test]
 changedir = {[molecule_common]changedir}
@@ -211,8 +196,6 @@ deps =
     {[molecule_common]deps}
 commands =
     {[testenv:molecule_version]commands}
-    {[testenv:molecule_lint]commands}
-    {[testenv:molecule_syntax]commands}
     {[testenv:molecule_test]commands}
 
 [testenv:collection]

--- a/src/tox_lsr/test_scripts/lsr_ci_runtox
+++ b/src/tox_lsr/test_scripts/lsr_ci_runtox
@@ -7,7 +7,7 @@
 #
 # LSR_MSCENARIOS is a space separated list of molecule scenarios.
 # LSR_ANSIBLES is a space separated list of Ansible package names with versions
-# in pip format, i.e 'ansible ansible==2.6 ansible==2.7 ansible=2.8'.
+# in pip format, i.e 'ansible ansible==2.8 ansible==2.9'.
 #
 # LSR_MSCENARIOS and LSR_ANSIBLES should be set as environment variables in the
 # CI test runner config.
@@ -18,23 +18,21 @@ tox_lsr_path=$(pip show tox-lsr 2> /dev/null | awk '/^Location: / {print $2}')
 SCRIPTDIR="$tox_lsr_path/tox_lsr/test_scripts"
 BANNERSIZE=90
 
-# LSR_MOLECULE_DOCKER_VERSION is the version string to pass
+# LSR_MOLECULE_DRIVER_VERSION is the version string to pass
 # to pip install - this is usually a comparison operator
 # followed by a version number e.g. '<4.3' but in reality
 # may be anything that pip allows to follow a package name
 # in an install specification
-if [ -z "${LSR_MOLECULE_DOCKER_VERSION:-}" ]; then
-  if type docker > /dev/null 2>&1; then
+if [ -z "${LSR_MOLECULE_DRIVER_VERSION:-}" ]; then
+  if [ "${LSR_MOLECULE_DRIVER:-docker}" = docker ] && type docker > /dev/null 2>&1; then
     DOCKER_SERVER_API_VERSION=$(docker version --format '{{.Server.APIVersion}}')
     case "$DOCKER_SERVER_API_VERSION" in
-    1.3[0-8]|1.[0-2]*) LSR_MOLECULE_DOCKER_VERSION='<4.3';;
-    *) LSR_MOLECULE_DOCKER_VERSION="";;
+    1.3[0-8]|1.[0-2]*) LSR_MOLECULE_DRIVER_VERSION='<4.3';;
+    *) LSR_MOLECULE_DRIVER_VERSION="";;
     esac
-  else
-    LSR_MOLECULE_DOCKER_VERSION=""
   fi
 fi
-export LSR_MOLECULE_DOCKER_VERSION
+export LSR_MOLECULE_DRIVER_VERSION
 
 . "$SCRIPTDIR/utils.sh"
 

--- a/tests/fixtures/test_tox_merge_ini/result.ini
+++ b/tests/fixtures/test_tox_merge_ini/result.ini
@@ -22,6 +22,9 @@ setenv = PYTHONPATH = {env:LSR_PYTHONPATH:}{toxinidir}/library:{toxinidir}/modul
 	LSR_CONFIGDIR = {lsr_configdir}
 	LSR_TOX_ENV_NAME = {envname}
 	LSR_TOX_ENV_DIR = {envdir}
+	LSR_ROLE2COLL_VERSION = 1.0.0
+	LSR_ROLE2COLL_NAMESPACE = fedora
+	LSR_ROLE2COLL_NAME = linux_system_roles
 	LOCAL1 = local1
 	LOCAL2 = local2
 deps = py{26,27,36,37,38}: pytest-cov
@@ -140,7 +143,8 @@ changedir = {toxinidir}
 deps = {env:LSR_ANSIBLE_DEP:ansible}
 	jmespath
 	{env:LSR_MOLECULE_DRIVER:docker}{env:LSR_MOLECULE_DRIVER_VERSION:}
-	molecule<3
+	molecule==3.*
+	molecule[{env:LSR_MOLECULE_DRIVER:docker}]
 	selinux
 	wcwidth==0.1.9;python_version=="3.6"
 	-rmolecule_extra_requirements.txt
@@ -152,18 +156,6 @@ deps = {[molecule_common]deps}
 commands = bash {[molecule_common]runsyspycmd} molecule --version
 	bash {[molecule_common]runsyspycmd} ansible --version
 
-[testenv:molecule_lint]
-changedir = {[molecule_common]changedir}
-deps = {[molecule_common]deps}
-commands = bash {[molecule_common]runsyspycmd} \
-	molecule lint -s {env:LSR_MSCENARIO:default} {posargs}
-
-[testenv:molecule_syntax]
-changedir = {[molecule_common]changedir}
-deps = {[molecule_common]deps}
-commands = bash {[molecule_common]runsyspycmd} \
-	molecule syntax -s {env:LSR_MSCENARIO:default} {posargs}
-
 [testenv:molecule_test]
 changedir = {[molecule_common]changedir}
 deps = {[molecule_common]deps}
@@ -174,8 +166,6 @@ commands = bash {[molecule_common]runsyspycmd} \
 changedir = {[molecule_common]changedir}
 deps = {[molecule_common]deps}
 commands = {[testenv:molecule_version]commands}
-	{[testenv:molecule_lint]commands}
-	{[testenv:molecule_syntax]commands}
 	{[testenv:molecule_test]commands}
 
 [testenv:collection]
@@ -184,7 +174,7 @@ ansible_python_interpreter = /usr/bin/python3
 deps = ruamel.yaml
 	ansible
 	jmespath
-commands = bash {lsr_scriptdir}/runcollection.sh {toxworkdir} master
+commands = bash {lsr_scriptdir}/runcollection.sh {toxworkdir} {env:LSR_ROLE2COLL_VERSION:master}
 
 [testenv:custom]
 changedir = {toxinidir}


### PR DESCRIPTION
Use molecule v3 instead of v2.  This means ansible 2.7 and earlier
are no longer supported.
If you want to use podman, use
`LSR_MOLECULE_DRIVER=podman tox -e molecule`
Use `LSR_MOLECULE_DRIVER_VERSION` if you need to use a specific
version of the driver.