### PR TITLE
RHELPLAN-65977,65978 - CI - add ansible-doc,-test test

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,3 +328,13 @@ lsr_some_shell_func ....
   etc.
 * `LSR_TOX_ENV_DIR` - the full path to the directory for the test environment
   e.g. `/path/to/ROLENAME/.tox/env-3.8`
+* `LSR_ROLE2COLL_RUN_ANSIBLE_TESTS` - if set to `true`, ansible-doc and ansible-test
+  are called in the collection test.
+  To enable it in the command line:
+  ```
+  LSR_ROLE2COLL_RUN_ANSIBLE_TESTS=true tox -e collection
+  ```
+  Set the var in .github/workflows/tox.yml to run in CI:
+  ```
+  LSR_ROLE2COLL_RUN_ANSIBLE_TESTS: true
+  ```

--- a/src/tox_lsr/test_scripts/runansible-doc.sh
+++ b/src/tox_lsr/test_scripts/runansible-doc.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT
+
+# A shell wrapper around ansible-doc.
+
+set -euo pipefail
+
+ME=$(basename "$0")
+SCRIPTDIR=$(readlink -f "$(dirname "$0")")
+
+. "$SCRIPTDIR/utils.sh"
+
+if [ "${LSR_ROLE2COLL_NAMESPACE:-}" = "" -o "${LSR_ROLE2COLL_NAME:-}" = "" ]; then
+    lsr_info "${ME}: Collection format only."
+    exit 1
+fi
+
+LSR_ROLE2COLL_MODULES="$MY_LSR_TOX_ENV_DIR"/ansible_collections/"$LSR_ROLE2COLL_NAMESPACE"/"$LSR_ROLE2COLL_NAME"/plugins/modules
+
+rval=0
+if [ -d "$LSR_ROLE2COLL_MODULES" ]; then
+  modules=()
+  for module_path in $( ls "$LSR_ROLE2COLL_MODULES" ); do
+    module_file=$( basename $module_path )
+    module="${module_file%%.*}"
+    modules+=("$LSR_ROLE2COLL_NAMESPACE"."$LSR_ROLE2COLL_NAME"."$module")
+  done
+
+  for module in "${modules[@]}"; do
+    lsr_info "${ME}: Checking $module ..."
+    if ! ANSIBLE_COLLECTIONS_PATHS="$MY_LSR_TOX_ENV_DIR" ansible-doc \
+        -M "$LSR_ROLE2COLL_MODULES" -vvv --type module "$module"; then
+        rval=1
+    fi
+  done
+fi
+exit $rval

--- a/src/tox_lsr/test_scripts/runansible-test.sh
+++ b/src/tox_lsr/test_scripts/runansible-test.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT
+
+# A shell wrapper around ansible-test.
+
+set -euo pipefail
+
+ME=$(basename "$0")
+SCRIPTDIR=$(readlink -f "$(dirname "$0")")
+
+. "$SCRIPTDIR/utils.sh"
+
+if [ "${LSR_ROLE2COLL_NAMESPACE:-}" = "" -o "${LSR_ROLE2COLL_NAME:-}" = "" ]; then
+    lsr_info "${ME}: Collection format only." 
+    exit 1
+fi
+
+LSR_ROLE2COLL_TOP="$MY_LSR_TOX_ENV_DIR"/ansible_collections/"$LSR_ROLE2COLL_NAMESPACE"/"$LSR_ROLE2COLL_NAME"
+
+rval=0
+if [ -d "$LSR_ROLE2COLL_TOP" ]; then
+  cd "$LSR_ROLE2COLL_TOP"
+  for test in $( ansible-test sanity --list-tests ); do
+    lsr_info "${ME}: Running $test ..."
+    if ! ansible-test sanity --test $test; then
+        rval=1
+    fi
+  done
+else
+  lsr_info "${ME}: $LSR_ROLE2COLL_TOP not found."
+  exit 1
+fi
+exit $rval


### PR DESCRIPTION
Adding runansible-doc.sh and runansible-test.sh, which are a shell wrapper of ansible-doc and ansible-test, respectively.

Modifying runcollection.sh to call runansible-doc and runansible-test.
To enable the tests, the following changes are made.
1) Do not exit on an error to continue the entire tests.
2) To pass the namespace and the collection name to runansible-doc
       and runansible-test, export LSR_ROLE2COLL_NAMESPACE and
       LSR_ROLE2COLL_NAME.
3) Since .tox is in .gitignore, ansible-test is skipped if the
       collection path is in LSR_TOX_ENV_DIR == .tox. Instead of the
       dir, use a temp dir outside of .tox for the collection path.
4) Introducing an environment variable LSR_ROLE2COLL_RUN_ANSIBLE_TEST
       to call runansible-doc and runansible-test.
       To run locally:
       `LSR_ROLE2COLL_RUN_ANSIBLE_TESTS=true tox -e collection`
       To run in CI, set the var to true in .github/workflows/tox.yml.
       `LSR_ROLE2COLL_RUN_ANSIBLE_TESTS: true`