### PR TITLE
collection testenv requires python six

### DIFF
--- a/src/tox_lsr/config_files/tox-default.ini
+++ b/src/tox_lsr/config_files/tox-default.ini
@@ -205,6 +205,7 @@ deps =
     ruamel.yaml
     ansible
     jmespath
+    six
 commands =
     bash {lsr_scriptdir}/runcollection.sh {toxworkdir} {env:LSR_ROLE2COLL_VERSION:master}
 

--- a/tests/fixtures/test_tox_merge_ini/result.ini
+++ b/tests/fixtures/test_tox_merge_ini/result.ini
@@ -174,6 +174,7 @@ ansible_python_interpreter = /usr/bin/python3
 deps = ruamel.yaml
 	ansible
 	jmespath
+        six
 commands = bash {lsr_scriptdir}/runcollection.sh {toxworkdir} {env:LSR_ROLE2COLL_VERSION:master}
 
 [testenv:custom]


### PR DESCRIPTION
The collection testenv uses the lsr_role2collection script which
requires python `six`.