### PR TITLE
improve collection testing

### DIFF
--- a/src/tox_lsr/config_files/collection_yamllint.yml
+++ b/src/tox_lsr/config_files/collection_yamllint.yml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: MIT
+---
+extends: default
+ignore: |
+  /.tox/
+  /tests/storage/
+rules:
+  line-length: disable
+  truthy: disable
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  document-start: disable
+  comments:
+    min-spaces-from-content: 1
+  comments-indentation: disable

--- a/src/tox_lsr/config_files/tox-default.ini
+++ b/src/tox_lsr/config_files/tox-default.ini
@@ -80,7 +80,7 @@ deps =
 commands =
     bash {lsr_scriptdir}/setup_module_utils.sh
     {[lsr_config]commands_pre}
-    black --check --diff --config {[lsr_black]configfile} \
+    black --check --diff --config {env:RUN_BLACK_CONFIG_FILE:{[lsr_black]configfile}} \
         {env:RUN_BLACK_EXTRA_ARGS:} {posargs} .
     {[lsr_config]commands_post}
 
@@ -115,7 +115,7 @@ deps =
 commands =
     bash {lsr_scriptdir}/setup_module_utils.sh
     {[lsr_config]commands_pre}
-    python -m flake8 --config {[lsr_flake8]configfile} \
+    python -m flake8 --config {env:RUN_FLAKE8_CONFIG_FILE:{[lsr_flake8]configfile}} \
         {env:RUN_FLAKE8_EXTRA_ARGS:} {posargs} .
     {[lsr_config]commands_post}
 
@@ -132,7 +132,7 @@ commands =
     cp {lsr_configdir}/yamllint_defaults.yml {[lsr_yamllint]configfile} {envtmpdir}
     sed -i "s,^extends: .*yamllint_defaults.yml$,extends: {envtmpdir}/yamllint_defaults.yml," {envtmpdir}/{[lsr_yamllint]configbasename}
     {[lsr_yamllint]commands_pre}
-    yamllint -c {envtmpdir}/{[lsr_yamllint]configbasename} {env:RUN_YAMLLINT_EXTRA_ARGS:} {posargs} .
+    yamllint -c {env:RUN_YAMLLINT_CONFIG_FILE:{envtmpdir}/{[lsr_yamllint]configbasename}} {env:RUN_YAMLLINT_EXTRA_ARGS:} {posargs} .
     {[lsr_config]commands_post}
 whitelist_externals =
     bash
@@ -202,10 +202,12 @@ commands =
 changedir = {toxinidir}
 ansible_python_interpreter = /usr/bin/python3
 deps =
-    ruamel.yaml
     ansible
     jmespath
+    ruamel.yaml
     six
+    voluptuous
+    yamllint
 commands =
     bash {lsr_scriptdir}/runcollection.sh {toxworkdir} {env:LSR_ROLE2COLL_VERSION:master}
 

--- a/src/tox_lsr/test_scripts/runcollection.sh
+++ b/src/tox_lsr/test_scripts/runcollection.sh
@@ -22,7 +22,7 @@ export LSR_ROLE2COLL_NAME="${LSR_ROLE2COLL_NAME:-linux_system_roles}"
 export MY_LSR_TOX_ENV_DIR=$( mktemp -d -t tox-XXXXXXXX )
 trap "rm -rf ${MY_LSR_TOX_ENV_DIR}" 0
 cd "$MY_LSR_TOX_ENV_DIR"
-testlist="yamllint,black,flake8,shellcheck"
+testlist="yamllint,flake8,shellcheck"
 # py38 - pyunit testing is not yet supported
 #testlist="${testlist},py38"
 
@@ -33,33 +33,13 @@ python lsr_role2collection.py --src-path "$TOPDIR/.." --dest-path "$MY_LSR_TOX_E
   --namespace "${LSR_ROLE2COLL_NAMESPACE}" --collection "${LSR_ROLE2COLL_NAME}" \
   2>&1 | tee "$MY_LSR_TOX_ENV_DIR"/collection.out
 
-line_length_warning() {
-    python -c 'import sys
-from configparser import ConfigParser
-cfg = ConfigParser()
-cfg.read(sys.argv[1])
-if "lsr_yamllint" not in cfg:
-  cfg["lsr_yamllint"] = {}
-cmdline = "sed -i -e \"s/\( *\)\(document-start: disable\)/\\1\\2\\n\\1line-length:\\n\\1\\1level: warning/\" {envtmpdir}/yamllint_defaults.yml"
-if "commands_pre" in cfg["lsr_yamllint"]:
-  cfg["lsr_yamllint"]["commands_pre"] += "\n" + cmdline
-else:
-  cfg["lsr_yamllint"]["commands_pre"] = cmdline
-cfg.write(open(sys.argv[1], "w"))
-' "$1"
-}
-
 cd ansible_collections/"${LSR_ROLE2COLL_NAMESPACE}"/"${LSR_ROLE2COLL_NAME}"
-# customize yamllint processing - make line-length reporting a warning
-if [ ! -f tox.ini ]; then
-    touch tox.ini
-fi
-line_length_warning tox.ini
 
 # unit testing not working yet - will need these and more
 #export RUN_PYTEST_UNIT_DIR="$role/unit"
 #export PYTHONPATH="$MY_LSR_TOX_ENV_DIR/ansible_collections/"${LSR_ROLE2COLL_NAME}"/"${LSR_ROLE2COLL_NAME}"/plugins/modules:$MY_LSR_TOX_ENV_DIR/ansible_collections/"${LSR_ROLE2COLL_NAME}"/"${LSR_ROLE2COLL_NAME}"/plugins/module_utils"
-tox -e "$testlist" 2>&1 | tee "$MY_LSR_TOX_ENV_DIR"/collection.tox.out || :
+RUN_YAMLLINT_CONFIG_FILE="$LSR_CONFIGDIR/collection_yamllint.yml" \
+tox --workdir "$TOXINIDIR/.tox" -e "$testlist" 2>&1 | tee "$MY_LSR_TOX_ENV_DIR"/collection.tox.out || :
 
 rval=0
 if [ "${LSR_ROLE2COLL_RUN_ANSIBLE_TESTS:-}" = "true" ]; then

--- a/tests/fixtures/test_tox_merge_ini/result.ini
+++ b/tests/fixtures/test_tox_merge_ini/result.ini
@@ -70,7 +70,7 @@ changedir = {toxinidir}
 deps = black
 commands = bash {lsr_scriptdir}/setup_module_utils.sh
 	{[lsr_config]commands_pre}
-	black --check --diff --config {[lsr_black]configfile} \
+	black --check --diff --config {env:RUN_BLACK_CONFIG_FILE:{[lsr_black]configfile}} \
 	{env:RUN_BLACK_EXTRA_ARGS:} {posargs} .
 	{[lsr_config]commands_post}
 
@@ -101,7 +101,7 @@ changedir = {toxinidir}
 deps = flake8>=3.5
 commands = bash {lsr_scriptdir}/setup_module_utils.sh
 	{[lsr_config]commands_pre}
-	python -m flake8 --config {[lsr_flake8]configfile} \
+	python -m flake8 --config {env:RUN_FLAKE8_CONFIG_FILE:{[lsr_flake8]configfile}} \
 	{env:RUN_FLAKE8_EXTRA_ARGS:} {posargs} .
 	{[lsr_config]commands_post}
 command = true
@@ -118,7 +118,7 @@ commands = bash -c 'test -d {envtmpdir} || mkdir -p {envtmpdir}'
 	cp {lsr_configdir}/yamllint_defaults.yml {[lsr_yamllint]configfile} {envtmpdir}
 	sed -i "s,^extends: .*yamllint_defaults.yml$,extends: {envtmpdir}/yamllint_defaults.yml," {envtmpdir}/{[lsr_yamllint]configbasename}
 	{[lsr_yamllint]commands_pre}
-	yamllint -c {envtmpdir}/{[lsr_yamllint]configbasename} {env:RUN_YAMLLINT_EXTRA_ARGS:} {posargs} .
+	yamllint -c {env:RUN_YAMLLINT_CONFIG_FILE:{envtmpdir}/{[lsr_yamllint]configbasename}} {env:RUN_YAMLLINT_EXTRA_ARGS:} {posargs} .
 	{[lsr_config]commands_post}
 whitelist_externals = bash
 	cp
@@ -171,10 +171,12 @@ commands = {[testenv:molecule_version]commands}
 [testenv:collection]
 changedir = {toxinidir}
 ansible_python_interpreter = /usr/bin/python3
-deps = ruamel.yaml
-	ansible
+deps = ansible
 	jmespath
-        six
+	ruamel.yaml
+	six
+	voluptuous
+	yamllint
 commands = bash {lsr_scriptdir}/runcollection.sh {toxworkdir} {env:LSR_ROLE2COLL_VERSION:master}
 
 [testenv:custom]


### PR DESCRIPTION
Get rid of `black` from collection testing.  It is too difficult
to make the generated code pass `black` testing.

Do not report `WARNINGS` from yamllint tests run against the
collection converted code.  It is too confusing for developers
to look at the tox log and determine which are "real" problems
they should be concerned about.

Instead of trying to reuse the .yamllint.yml etc. lint suppression
files from each repo, just create a single suppressions file that
is a superset of all of the suppressions from all of the repos.
Add environment variables like `RUN_YAMLLINT_CONFIG_FILE` so that
the collection test can override the lint check with the
suppressions used by collections.

When running `tox` in the collection directory, set the `--workdir`
to the original `repo/.tox/` directory so that ansible-doc and
ansible-lint won't try to analyze all of the files in the `.tox/`
directory.

Add additional `deps` required for ansible-doc and ansible-lint
tests.