### PR TITLE
RHELPLAN-42936 - publish system roles Collection to Automation Hub

### DIFF
--- a/src/tox_lsr/config_files/tox-default.ini
+++ b/src/tox_lsr/config_files/tox-default.ini
@@ -209,6 +209,8 @@ deps =
     voluptuous
     yamllint
     rstcheck
+    pycodestyle
+    pylint
 commands =
     bash {lsr_scriptdir}/runcollection.sh {toxworkdir} {env:LSR_ROLE2COLL_VERSION:master}
 

--- a/src/tox_lsr/test_scripts/runcollection.sh
+++ b/src/tox_lsr/test_scripts/runcollection.sh
@@ -43,6 +43,9 @@ tox --workdir "$TOXINIDIR/.tox" -e "$testlist" 2>&1 | tee "$MY_LSR_TOX_ENV_DIR"/
 
 rval=0
 if [ "${LSR_ROLE2COLL_RUN_ANSIBLE_TESTS:-}" = "true" ]; then
+    # ansible-test needs the modules and meta data
+    pip install pycodestyle pylint
+    curl -s -L -o galaxy.yml "${automaintenancerepo}${STABLE_TAG}"/galaxy.yml
     if ! ${SCRIPTDIR}/runansible-doc.sh; then
         rval=1
     fi

--- a/src/tox_lsr/test_scripts/runcollection.sh
+++ b/src/tox_lsr/test_scripts/runcollection.sh
@@ -43,8 +43,7 @@ tox --workdir "$TOXINIDIR/.tox" -e "$testlist" 2>&1 | tee "$MY_LSR_TOX_ENV_DIR"/
 
 rval=0
 if [ "${LSR_ROLE2COLL_RUN_ANSIBLE_TESTS:-}" = "true" ]; then
-    # ansible-test needs the modules and meta data
-    pip install pycodestyle pylint
+    # ansible-test needs meta data
     curl -s -L -o galaxy.yml "${automaintenancerepo}${STABLE_TAG}"/galaxy.yml
     if ! ${SCRIPTDIR}/runansible-doc.sh; then
         rval=1

--- a/tests/fixtures/test_tox_merge_ini/result.ini
+++ b/tests/fixtures/test_tox_merge_ini/result.ini
@@ -178,6 +178,8 @@ deps = ansible
 	voluptuous
 	yamllint
 	rstcheck
+	pycodestyle
+	pylint
 commands = bash {lsr_scriptdir}/runcollection.sh {toxworkdir} {env:LSR_ROLE2COLL_VERSION:master}
 
 [testenv:custom]


### PR DESCRIPTION
Importing to Automation Hub runs ansible-test. The test calls ansible-test which requires the the modules pycodestyle and pylint as well as meta data.