### PR TITLE
RHELPLAN-68381 - CI - ansible version 2.10 in tox-lsr

### DIFF
--- a/src/tox_lsr/config_files/tox-default.ini
+++ b/src/tox_lsr/config_files/tox-default.ini
@@ -92,7 +92,7 @@ basepython = python2.7
 passenv = RUN_PYLINT_*
 changedir = {toxinidir}
 deps =
-    ansible
+    ansible==2.10.*
     colorama
     pylint>=1.8.4
     -rpylint_extra_requirements.txt
@@ -202,7 +202,7 @@ commands =
 changedir = {toxinidir}
 ansible_python_interpreter = /usr/bin/python3
 deps =
-    ansible
+    ansible==2.10.*
     jmespath
     ruamel.yaml
     six
@@ -236,6 +236,7 @@ configfile = {lsr_configdir}/ansible-lint.yml
 [testenv:ansible-lint]
 changedir = {toxinidir}
 deps =
+    ansible==2.10.*
     ansible-lint==4.3.5
 commands =
     bash {lsr_scriptdir}/setup_module_utils.sh

--- a/tests/fixtures/test_tox_merge_ini/result.ini
+++ b/tests/fixtures/test_tox_merge_ini/result.ini
@@ -81,7 +81,7 @@ configfile = {lsr_configdir}/pylintrc
 basepython = python2.7
 passenv = RUN_PYLINT_*
 changedir = {toxinidir}
-deps = ansible
+deps = ansible==2.10.*
 	colorama
 	pylint>=1.8.4
 	-rpylint_extra_requirements.txt
@@ -171,7 +171,7 @@ commands = {[testenv:molecule_version]commands}
 [testenv:collection]
 changedir = {toxinidir}
 ansible_python_interpreter = /usr/bin/python3
-deps = ansible
+deps = ansible==2.10.*
 	jmespath
 	ruamel.yaml
 	six
@@ -203,7 +203,9 @@ configfile = {lsr_configdir}/ansible-lint.yml
 
 [testenv:ansible-lint]
 changedir = {toxinidir}
-deps = ansible-lint==4.3.5
+deps =
+    ansible==2.10.*
+    ansible-lint==4.3.5
 commands = bash {lsr_scriptdir}/setup_module_utils.sh
 	{[lsr_config]commands_pre}
 	ansible-lint -v --exclude=tests/roles -c {[lsr_ansible-lint]configfile} \


### PR DESCRIPTION
Description:
We have recently begun seeing issues in CI testing that are due to
the fact that ansible has released version 3.0 to pypi.  We should
lock down the version of ansible to ansible==2.10.* in tox-lsr.