### PR TITLE
add ability to use ansible-test sanity with docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,8 @@ environment variables:
 * `RUN_BLACK_CONFIG_FILE` - path to config file to use instead of the default
 * `RUN_FLAKE8_CONFIG_FILE` - path to config file to use instead of the default
 * `RUN_YAMLLINT_CONFIG_FILE` - path to config file to use instead of the default
+* `LSR_ANSIBLE_TEST_DOCKER` - if set to `true`, `ansible-test` will be run with
+  `--docker`
 
 These environment variables have been removed:
 * `RUN_PYLINT_INCLUDE` - use `RUN_PYLINT_EXTRA_ARGS`

--- a/src/tox_lsr/test_scripts/runansible-test.sh
+++ b/src/tox_lsr/test_scripts/runansible-test.sh
@@ -30,7 +30,7 @@ if [ "${LSR_ANSIBLE_TEST_DEBUG:-false}" = true ]; then
   truncate_val="0"
   default_v_arg="-vv"
   ansible_test_filter() {
-    : ;
+    cat
   }
 else
   default_v_arg=""
@@ -63,6 +63,11 @@ for file in "$TOXINIDIR"/.sanity-ansible-ignore-*.txt; do
     cp "$file" "tests/sanity/${file//*.sanity-ansible-}"
   fi
 done
+
+if [ "${LSR_ANSIBLE_TEST_DOCKER:-false}" = true ]; then
+  ansible-test sanity --docker 2>&1 | ansible_test_filter
+  exit 0
+fi
 
 # remove the current venv from PATH
 if [ -n "${VIRTUAL_ENV:-}" ] && [[ "${PATH}" == "${VIRTUAL_ENV:-}/bin:"* ]]; then


### PR DESCRIPTION
If you set `LSR_ANSIBLE_TEST_DOCKER=true` it will run
`ansible-test sanity --docker`