### PR TITLE
have to use ansible 2.9 for pylint with python 2.7

### DIFF
--- a/src/tox_lsr/config_files/tox-default.ini
+++ b/src/tox_lsr/config_files/tox-default.ini
@@ -96,7 +96,7 @@ basepython = python2.7
 passenv = RUN_PYLINT_*
 changedir = {toxinidir}
 deps =
-    ansible==2.11.*
+    ansible==2.9.*
     colorama
     pylint>=1.8.4
     -rpylint_extra_requirements.txt

--- a/tests/fixtures/test_tox_merge_ini/result.ini
+++ b/tests/fixtures/test_tox_merge_ini/result.ini
@@ -84,7 +84,7 @@ configfile = {lsr_configdir}/pylintrc
 basepython = python2.7
 passenv = RUN_PYLINT_*
 changedir = {toxinidir}
-deps = ansible==2.11.*
+deps = ansible==2.9.*
 	colorama
 	pylint>=1.8.4
 	-rpylint_extra_requirements.txt


### PR DESCRIPTION
use ansible 2.9 for pylint testing with python 2.7