### PR TITLE
add support for py39

### DIFF
--- a/src/tox_lsr/config_files/tox-default.ini
+++ b/src/tox_lsr/config_files/tox-default.ini
@@ -30,10 +30,10 @@ setenv =
     LSR_ROLE2COLL_NAMESPACE = fedora
     LSR_ROLE2COLL_NAME = linux_system_roles
 deps =
-    py{26,27,36,37,38}: pytest-cov
-    py{27,36,37,38}: pytest>=3.5.1
+    py{26,27,36,37,38,39}: pytest-cov
+    py{27,36,37,38,39}: pytest>=3.5.1
     py26: pytest
-    py{26,27,36,37,38}: -rpytest_extra_requirements.txt
+    py{26,27,36,37,38,39}: -rpytest_extra_requirements.txt
 whitelist_externals =
     bash
 commands =

--- a/tests/fixtures/test_tox_merge_ini/result.ini
+++ b/tests/fixtures/test_tox_merge_ini/result.ini
@@ -27,10 +27,10 @@ setenv = PYTHONPATH = {env:LSR_PYTHONPATH:}{toxinidir}/library:{toxinidir}/modul
 	LSR_ROLE2COLL_NAME = linux_system_roles
 	LOCAL1 = local1
 	LOCAL2 = local2
-deps = py{26,27,36,37,38}: pytest-cov
-	py{27,36,37,38}: pytest>=3.5.1
+deps = py{26,27,36,37,38,39}: pytest-cov
+	py{27,36,37,38,39}: pytest>=3.5.1
 	py26: pytest
-	py{26,27,36,37,38}: -rpytest_extra_requirements.txt
+	py{26,27,36,37,38,39}: -rpytest_extra_requirements.txt
 	localdep1
 	localdep2
 whitelist_externals = bash


### PR DESCRIPTION
You can now run pytest with python39 `tox -e py39`