### PR TITLE
support ansible-core 2.12; scan for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,13 +322,13 @@ environment variables:
 * `LSR_ANSIBLE_TEST_DOCKER` - if set to `true`, `ansible-test` will be run with
   `--docker`
 * `LSR_ANSIBLE_LINT_DEP` - this is the dep to pass when doing the pip install of
-  ansible for ansible-lint.  The default is `ansible-core==2.11.*`.
+  ansible for ansible-lint.  The default is `ansible-core==2.12.*`.
 * `LSR_ANSIBLE_LINT_VER` - this is the version of ansible-lint to install for
   the ansible-lint testenv.  The default is `5.2.0`.
 * `LSR_ANSIBLE_TEST_DEP` - this is the dep to pass when doing the pip install of
-  ansible for ansible-test.  The default is `ansible-core==2.11.*`.
+  ansible for ansible-test.  The default is `ansible-core==2.12.*`.
 * `LSR_PYLINT_ANSIBLE_DEP` - this is the dep to pass when doing the pip install of
-  ansible for pylint.  The default is `ansible-core==2.11.*`.
+  ansible for pylint.  The default is `ansible-core==2.12.*`.
 
 These environment variables have been removed:
 * `RUN_PYLINT_INCLUDE` - use `RUN_PYLINT_EXTRA_ARGS`
@@ -379,10 +379,11 @@ and an Ansible inventory. There are two test envs that can be used to run these
 tests:
 * `qemu` - tests against the latest version of ansible supported by the roles
 * `qemu-ansible-core-2.11` - tests against ansible-core 2.11
+* `qemu-ansible-core-2.12` - tests against ansible-core 2.12
 
 These tests run in one of two modes, depending on which of the following
 arguments you provide.  Note that you must use `--` on the command line after
-the `-e qemu` or `-e qemu-ansible-core-2.11` so that `tox` will not attempt to
+the `-e qemu` or `-e qemu-ansible-core-2.x` so that `tox` will not attempt to
 interpret these as `tox` arguments:
 ```
 tox -e qemu -- --image-name fedora-34 ...

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,7 +69,7 @@ formats = zip, gztar
 
 [flake8]
 filename = *.py,*.pyi
-ignore = E302,E704,H301,H304,H306,H404,H405,W503
+ignore = E302,E704,H216,H301,H304,H306,H404,H405,W503
 select = E,F,W,C,G,H
 enable-extensions = G,H
 max-line-length = 79

--- a/src/tox_lsr/config_files/ansible-lint.yml
+++ b/src/tox_lsr/config_files/ansible-lint.yml
@@ -1,4 +1,3 @@
 ---
 skip_list:
-- empty-string-compare
-- unnamed-task
+- role-name

--- a/src/tox_lsr/config_files/tox-default.ini
+++ b/src/tox_lsr/config_files/tox-default.ini
@@ -2,7 +2,7 @@
 [tox]
 envlist =
     black, pylint, flake8, yamllint
-    py{26,27,36,37,38}, shellcheck
+    py{26,27,36,37,38,39}, shellcheck
     collection, ansible-lint, custom
     ansible-test
 skipsdist = true
@@ -231,9 +231,11 @@ configfile = {lsr_configdir}/ansible-lint.yml
 
 [testenv:ansible-lint]
 changedir = {toxinidir}
+# needed currently for ansible-core 2.12
+pip_pre = true
 deps =
-    {env:LSR_ANSIBLE_LINT_DEP:ansible-core==2.11.*}
-    ansible-lint=={env:LSR_ANSIBLE_LINT_VER:5.2.0}
+    {env:LSR_ANSIBLE_LINT_DEP:ansible-core==2.12.*}
+    ansible-lint=={env:LSR_ANSIBLE_LINT_VER:5.2.1}
 commands =
     bash {lsr_scriptdir}/setup_module_utils.sh
     {[lsr_config]commands_pre}
@@ -246,8 +248,10 @@ commands =
 # when running in a venv that uses basepython 3.9 or later
 # ansible 2.10 seems better in this respect
 basepython = python3
+# needed currently for ansible-core 2.12
+pip_pre = true
 deps =
-    {env:LSR_ANSIBLE_TEST_DEP:ansible-core==2.11.*}
+    {env:LSR_ANSIBLE_TEST_DEP:ansible-core==2.12.*}
 commands =
     bash {lsr_scriptdir}/runansible-test.sh
 
@@ -285,3 +289,28 @@ deps =
     ansible-core==2.11.*
 commands =
     {[qemu_common]commands}
+
+[testenv:qemu-ansible-core-2.12]
+changedir = {[qemu_common]changedir}
+basepython = {[qemu_common]basepython}
+setenv =
+    {[qemu_common]setenv}
+# needed currently for ansible-core 2.12
+pip_pre = true
+deps =
+    {[qemu_common]deps}
+    ansible-core==2.12.*
+commands =
+    {[qemu_common]commands}
+
+[testenv:ansible-plugin-scan]
+changedir = {toxinidir}
+basepython = python3
+whitelist_externals =
+    curl
+deps =
+    ansible==4.*
+    jinja2==2.7.*
+commands =
+    curl -L -o {envdir}/report-modules-plugins.py https://raw.githubusercontent.com/linux-system-roles/auto-maintenance/master/report-modules-plugins.py
+    python {envdir}/report-modules-plugins.py --details .

--- a/tests/fixtures/test_tox_merge_ini/result.ini
+++ b/tests/fixtures/test_tox_merge_ini/result.ini
@@ -198,8 +198,9 @@ configfile = {lsr_configdir}/ansible-lint.yml
 
 [testenv:ansible-lint]
 changedir = {toxinidir}
-deps = {env:LSR_ANSIBLE_LINT_DEP:ansible-core==2.11.*}
-	ansible-lint=={env:LSR_ANSIBLE_LINT_VER:5.2.0}
+pip_pre = true
+deps = {env:LSR_ANSIBLE_LINT_DEP:ansible-core==2.12.*}
+	ansible-lint=={env:LSR_ANSIBLE_LINT_VER:5.2.1}
 commands = bash {lsr_scriptdir}/setup_module_utils.sh
 	{[lsr_config]commands_pre}
 	ansible-lint -v --exclude=tests/roles -c {[lsr_ansible-lint]configfile} \
@@ -208,7 +209,8 @@ commands = bash {lsr_scriptdir}/setup_module_utils.sh
 
 [testenv:ansible-test]
 basepython = python3
-deps = {env:LSR_ANSIBLE_TEST_DEP:ansible-core==2.11.*}
+pip_pre = true
+deps = {env:LSR_ANSIBLE_TEST_DEP:ansible-core==2.12.*}
 commands = bash {lsr_scriptdir}/runansible-test.sh
 
 [qemu_common]
@@ -236,6 +238,24 @@ setenv = {[qemu_common]setenv}
 deps = {[qemu_common]deps}
 	ansible-core==2.11.*
 commands = {[qemu_common]commands}
+
+[testenv:qemu-ansible-core-2.12]
+changedir = {[qemu_common]changedir}
+basepython = {[qemu_common]basepython}
+setenv = {[qemu_common]setenv}
+pip_pre = true
+deps = {[qemu_common]deps}
+	ansible-core==2.12.*
+commands = {[qemu_common]commands}
+
+[testenv:ansible-plugin-scan]
+changedir = {toxinidir}
+basepython = python3
+whitelist_externals = curl
+deps = ansible==4.*
+	jinja2==2.7.*
+commands = curl -L -o {envdir}/report-modules-plugins.py https://raw.githubusercontent.com/linux-system-roles/auto-maintenance/master/report-modules-plugins.py
+	python {envdir}/report-modules-plugins.py --details .
 
 [custom_common]
 setenv = CUSTOMCOMMON = customcommon

--- a/tox.ini
+++ b/tox.ini
@@ -25,11 +25,11 @@ deps =
     coveralls
     py
     PyYAML<5.1 ; python_version < "2.7"
-    tox30: tox==3.0
+    tox30: tox==3.*
     tox20: tox==2.4
     py{26,27}: mock
 commands =
-    {env:SAFETY_CMD:safety} check -i 40291 -i 38765 -i 39611 --full-report  # ignore pip, PyYAML problems
+    {env:SAFETY_CMD:safety} check -i 42218 -i 40291 -i 38765 -i 39611 --full-report  # ignore pip, PyYAML problems
     pytest --cov=tox_lsr --cov-report=term-missing tests
     {env:COVERALLS_CMD:coveralls --output={envname}-coverage.txt}
 
@@ -82,7 +82,7 @@ description =
 deps =
     flake8
     flake8-logging-format
-    hacking
+    hacking==4.*
 commands =
     flake8 src/tox_lsr tests/unit
 


### PR DESCRIPTION
Add support for ansible-core 2.12.  This is currently pre-release so
have to use `pip_pre` to install it.
Add a check for non-core plugins - `ansible-plugin-scan` - so we can
catch in CI when a role uses a non-core plugin.