### PR TITLE
collections check for plugin fqcn

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,8 @@ environment variables:
   ansible for ansible-test.  The default is `ansible-core==2.12.*`.
 * `LSR_PYLINT_ANSIBLE_DEP` - this is the dep to pass when doing the pip install of
   ansible for pylint.  The default is `ansible-core==2.12.*`.
+* `LSR_RUN_TEST_DIR` - this is the directory to use to override `changedir`, for
+  those tests that need it, primarily the tests run "recursively" via `-e collection`
 
 These environment variables have been removed:
 * `RUN_PYLINT_INCLUDE` - use `RUN_PYLINT_EXTRA_ARGS`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,4 +20,4 @@ line_length = 79
 max-line-length = 79
 
 [tool.pylint."message control"]
-disable = "R0205"
+disable = "R0205,R0801"

--- a/src/tox_lsr/config_files/tox-default.ini
+++ b/src/tox_lsr/config_files/tox-default.ini
@@ -113,7 +113,7 @@ configfile = {lsr_configdir}/flake8.ini
 [testenv:flake8]
 basepython = python2.7
 passenv = RUN_FLAKE8_*
-changedir = {toxinidir}
+changedir = {env:LSR_RUN_TEST_DIR:toxinidir}
 deps =
     flake8>=3.5
 commands =
@@ -129,7 +129,7 @@ configbasename = yamllint.yml
 commands_pre =
 
 [testenv:yamllint]
-changedir = {toxinidir}
+changedir = {env:LSR_RUN_TEST_DIR:toxinidir}
 deps = yamllint
 commands =
     bash -c 'test -d {envtmpdir} || mkdir -p {envtmpdir}'
@@ -218,7 +218,7 @@ commands =
     bash -c 'if [ -f {toxinidir}/.travis/custom.sh ]; then bash {toxinidir}/.travis/custom.sh; fi'
 
 [testenv:shellcheck]
-changedir = {toxinidir}
+changedir = {env:LSR_RUN_TEST_DIR:toxinidir}
 envdir = {toxworkdir}/env-shellcheck
 commands =
     bash {lsr_scriptdir}/setup_module_utils.sh
@@ -257,7 +257,6 @@ basepython = python3
 setenv =
     {[testenv]setenv}
 deps =
-    jinja2==2.7.*  # want to ensure things work on jinja 2.7
     productmd  # needed for runqemu
     PyYAML  # needed for runqemu
     ruamel.yaml  # needed for collection support
@@ -272,6 +271,7 @@ setenv =
 deps =
     {[qemu_common]deps}
     ansible==2.9.*
+    jinja2==2.7.* ; python_version <= 3.9
 commands =
     {[qemu_common]commands}
 
@@ -298,16 +298,18 @@ commands =
     {[qemu_common]commands}
 
 [testenv:ansible-plugin-scan]
-changedir = {toxinidir}
+changedir = {env:LSR_RUN_TEST_DIR:toxinidir}
 basepython = python3
 whitelist_externals =
     curl
+    bash
 deps =
-    ansible==4.*
-    jinja2==2.7.*
+    ansible==5.*
+    jinja2==2.7.* ; python_version <= "3.9"
 commands =
     curl -L -o {envdir}/report-modules-plugins.py https://raw.githubusercontent.com/linux-system-roles/auto-maintenance/master/report-modules-plugins.py
-    python {envdir}/report-modules-plugins.py --details .
+    python {env:LSR_REPORT_MODULES_PLUGINS:{envdir}/report-modules-plugins.py} \
+      {env:RUN_PLUGIN_SCAN_EXTRA_ARGS:} --details {posargs} .
 
 [testenv:ansible-managed-var-comment]
 changedir = {toxinidir}

--- a/src/tox_lsr/test_scripts/runcollection.sh
+++ b/src/tox_lsr/test_scripts/runcollection.sh
@@ -14,19 +14,29 @@ SCRIPTDIR=$(readlink -f "$(dirname "$0")")
 role=$(basename "${TOPDIR}")
 STABLE_TAG=${1:-master}
 
-testlist="yamllint,flake8,shellcheck"
+testlist="yamllint,flake8,shellcheck,ansible-plugin-scan"
 # py38 - pyunit testing is not yet supported
 #testlist="${testlist},py38"
 
-automaintenancerepo=https://raw.githubusercontent.com/linux-system-roles/auto-maintenance/
-curl -s -L -o "$LSR_TOX_ENV_DIR/tmp/lsr_role2collection.py" "${automaintenancerepo}${STABLE_TAG}"/lsr_role2collection.py
-curl -s -L -o "$LSR_TOX_ENV_DIR/tmp/runtime.yml" "${automaintenancerepo}${STABLE_TAG}"/lsr_role2collection/runtime.yml
+if [ -z "${LSR_ROLE2COLL_PATH:-}" ]; then
+  automaintenancerepo=https://raw.githubusercontent.com/linux-system-roles/auto-maintenance/
+  curl -s -L -o "$LSR_TOX_ENV_DIR/tmp/lsr_role2collection.py" "${automaintenancerepo}${STABLE_TAG}"/lsr_role2collection.py
+  curl -s -L -o "$LSR_TOX_ENV_DIR/tmp/runtime.yml" "${automaintenancerepo}${STABLE_TAG}"/lsr_role2collection/runtime.yml
+  # ansible-test needs meta data
+  curl -s -L -o "$LSR_TOX_ENV_DIR/tmp/galaxy.yml" "${automaintenancerepo}${STABLE_TAG}"/galaxy.yml
+else
+  cp "$LSR_ROLE2COLL_PATH/lsr_role2collection.py" "$LSR_TOX_ENV_DIR/tmp"
+  cp "$LSR_ROLE2COLL_PATH/lsr_role2collection/runtime.yml" "$LSR_TOX_ENV_DIR/tmp"
+  cp "$LSR_ROLE2COLL_PATH/galaxy.yml" "$LSR_TOX_ENV_DIR/tmp"
+fi
 
 rm -rf "$TOX_WORK_DIR/ansible_collections"
 python "$LSR_TOX_ENV_DIR/tmp/lsr_role2collection.py" --src-path "$TOPDIR/.." --dest-path "$TOX_WORK_DIR" \
   --role "$role" --namespace "${LSR_ROLE2COLL_NAMESPACE}" --collection "${LSR_ROLE2COLL_NAME}" \
   --meta-runtime "$LSR_TOX_ENV_DIR/tmp/runtime.yml" --subrole-prefix "private_${role}_subrole_" \
   2>&1 | tee "$TOX_ENV_DIR/collection.out"
+
+cp "$LSR_TOX_ENV_DIR/tmp/galaxy.yml" "$TOX_WORK_DIR/ansible_collections/$LSR_ROLE2COLL_NAMESPACE/$LSR_ROLE2COLL_NAME"
 
 # create the collection in this dir to share with other testenvs
 cd "$TOX_WORK_DIR/ansible_collections/$LSR_ROLE2COLL_NAMESPACE/$LSR_ROLE2COLL_NAME"
@@ -35,6 +45,8 @@ cd "$TOX_WORK_DIR/ansible_collections/$LSR_ROLE2COLL_NAMESPACE/$LSR_ROLE2COLL_NA
 #export RUN_PYTEST_UNIT_DIR="$role/unit"
 #export PYTHONPATH="$MY_LSR_TOX_ENV_DIR/ansible_collections/"${LSR_ROLE2COLL_NAME}"/"${LSR_ROLE2COLL_NAME}"/plugins/modules:$MY_LSR_TOX_ENV_DIR/ansible_collections/"${LSR_ROLE2COLL_NAME}"/"${LSR_ROLE2COLL_NAME}"/plugins/module_utils"
 RUN_YAMLLINT_CONFIG_FILE="$LSR_CONFIGDIR/collection_yamllint.yml" \
+RUN_PLUGIN_SCAN_EXTRA_ARGS="--check-fqcn=plugins" \
+LSR_RUN_TEST_DIR="$TOX_WORK_DIR/ansible_collections/$LSR_ROLE2COLL_NAMESPACE/$LSR_ROLE2COLL_NAME" \
 TOXENV="" tox --workdir "$TOXINIDIR/.tox" -e "$testlist" 2>&1 | tee "$TOX_ENV_DIR/collection.tox.out" || :
 
 if grep "^ERROR: .*failed" "$TOX_ENV_DIR/collection.tox.out"; then
@@ -42,8 +54,5 @@ if grep "^ERROR: .*failed" "$TOX_ENV_DIR/collection.tox.out"; then
   This usually indicates either a problem with the collection conversion,
   or additional error suppressions are needed."
 fi
-
-# ansible-test needs meta data
-curl -s -L -o galaxy.yml "${automaintenancerepo}${STABLE_TAG}/galaxy.yml"
 
 exit 0

--- a/tests/fixtures/test_tox_merge_ini/result.ini
+++ b/tests/fixtures/test_tox_merge_ini/result.ini
@@ -100,7 +100,7 @@ configfile = {lsr_configdir}/flake8.ini
 [testenv:flake8]
 basepython = python2.7
 passenv = RUN_FLAKE8_*
-changedir = {toxinidir}
+changedir = {env:LSR_RUN_TEST_DIR:toxinidir}
 deps = flake8>=3.5
 commands = bash {lsr_scriptdir}/setup_module_utils.sh
 	{[lsr_config]commands_pre}
@@ -115,7 +115,7 @@ configbasename = yamllint.yml
 commands_pre = 
 
 [testenv:yamllint]
-changedir = {toxinidir}
+changedir = {env:LSR_RUN_TEST_DIR:toxinidir}
 deps = yamllint
 commands = bash -c 'test -d {envtmpdir} || mkdir -p {envtmpdir}'
 	cp {lsr_configdir}/yamllint_defaults.yml {[lsr_yamllint]configfile} {envtmpdir}
@@ -186,7 +186,7 @@ commands = override_custom_cmd
 setenv = OVERRIDE_CUSTOM = override_custom
 
 [testenv:shellcheck]
-changedir = {toxinidir}
+changedir = {env:LSR_RUN_TEST_DIR:toxinidir}
 envdir = {toxworkdir}/env-shellcheck
 commands = bash {lsr_scriptdir}/setup_module_utils.sh
 	{[lsr_config]commands_pre}
@@ -215,8 +215,7 @@ commands = bash {lsr_scriptdir}/runansible-test.sh
 changedir = {toxinidir}
 basepython = python3
 setenv = {[testenv]setenv}
-deps = jinja2==2.7.*  # want to ensure things work on jinja 2.7
-	productmd  # needed for runqemu
+deps = productmd  # needed for runqemu
 	PyYAML  # needed for runqemu
 	ruamel.yaml  # needed for collection support
 commands = python {lsr_scriptdir}/runqemu.py {posargs}
@@ -227,6 +226,7 @@ basepython = {[qemu_common]basepython}
 setenv = {[qemu_common]setenv}
 deps = {[qemu_common]deps}
 	ansible==2.9.*
+	jinja2==2.7.* ; python_version <= 3.9
 commands = {[qemu_common]commands}
 
 [testenv:qemu-ansible-core-2.11]
@@ -246,13 +246,15 @@ deps = {[qemu_common]deps}
 commands = {[qemu_common]commands}
 
 [testenv:ansible-plugin-scan]
-changedir = {toxinidir}
+changedir = {env:LSR_RUN_TEST_DIR:toxinidir}
 basepython = python3
 whitelist_externals = curl
-deps = ansible==4.*
-	jinja2==2.7.*
+	bash
+deps = ansible==5.*
+	jinja2==2.7.* ; python_version <= "3.9"
 commands = curl -L -o {envdir}/report-modules-plugins.py https://raw.githubusercontent.com/linux-system-roles/auto-maintenance/master/report-modules-plugins.py
-	python {envdir}/report-modules-plugins.py --details .
+	python {env:LSR_REPORT_MODULES_PLUGINS:{envdir}/report-modules-plugins.py} \
+	{env:RUN_PLUGIN_SCAN_EXTRA_ARGS:} --details {posargs} .
 
 [testenv:ansible-managed-var-comment]
 changedir = {toxinidir}

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -25,7 +25,14 @@ import pkg_resources
 # on the same line, so I have to disable it before the line
 # pylint: disable=no-member,no-name-in-module,import-error
 import py.iniconfig
-import unittest2
+
+# pylint: disable=ungrouped-imports,duplicate-code
+try:
+    from unittest2 import TestCase
+except ImportError:
+    from unittest import TestCase
+except AttributeError:
+    from unittest import TestCase
 
 from tox_lsr.hooks import (
     CONFIG_FILES_SUBDIR,
@@ -52,7 +59,7 @@ from .utils import MockConfig
 # pylint: disable=protected-access
 
 
-class HooksTestCase(unittest2.TestCase):
+class HooksTestCase(TestCase):
     def setUp(self):
         self.toxworkdir = tempfile.mkdtemp()
         patch(

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -3,11 +3,17 @@
 #
 """Test for version presence."""
 
-import unittest2
+# pylint: disable=duplicate-code
+try:
+    from unittest2 import TestCase
+except ImportError:
+    from unittest import TestCase
+except AttributeError:
+    from unittest import TestCase
 
 from tox_lsr import __version__
 
 
-class VersionTestCase(unittest2.TestCase):
+class VersionTestCase(TestCase):
     def test_version(self):
         self.assertIsInstance(__version__, str)

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 [tox]
 envlist =
     py26-tox20
-    py{27,35,36,37,38,39}-tox30
+    py{27,35,36,37,38,39,310}-tox30
     black, isort, pylint, flake8, bandit, pydocstyle
     shellcheck
 skip_missing_interpreters = True
@@ -29,7 +29,7 @@ deps =
     tox20: tox==2.4
     py{26,27}: mock
 commands =
-    {env:SAFETY_CMD:safety} check -i 42559 -i 42218 -i 40291 -i 38765 -i 39611 --full-report  # ignore pip, PyYAML problems
+    {env:SAFETY_CMD:safety} check -i 42559 -i 42218 -i 40291 -i 38765 -i 39611 -i 44492 --full-report  # ignore pip, PyYAML problems
     pytest --cov=tox_lsr --cov-report=term-missing tests
     {env:COVERALLS_CMD:coveralls --output={envname}-coverage.txt}
 


### PR DESCRIPTION
add `ansible-plugin-scan` to `-e collection` - the reason is that
in the collection format, plugins other than modules must use
FQCN
This also required the ability to set the `changedir` for the
tests that `-e collection` invokes using `LSR_RUN_TEST_DIR`
Use jinja 2.7 if python is 3.9 or lower to better test for jinja
constructs that are not supported on all platforms.
For ease of testing, allow using local collection and plugin scan
scripts by using `LSR_ROLE2COLL_DIR` and `LSR_REPORT_MODULES_PLUGINS`.

add support for python 3.10