### PR TITLE
py26: Prepare to fix the unit tests again

### DIFF
--- a/src/tox_lsr/config_files/tox-default.ini
+++ b/src/tox_lsr/config_files/tox-default.ini
@@ -53,7 +53,7 @@ configfile = {lsr_configdir}/pytest.ini
 
 [testenv:py26]
 install_command =
-    pip install {opts} {packages}
+    pip install --index-url=file:///local_pypi_index/simple {opts} {packages}
 list_dependencies_command =
     pip freeze
 basepython = python2.6

--- a/src/tox_lsr/config_files/tox-default.ini
+++ b/src/tox_lsr/config_files/tox-default.ini
@@ -37,7 +37,12 @@ deps =
     py{26,27,36,37,38,39}: -rpytest_extra_requirements.txt
 whitelist_externals =
     bash
+    mkdir
+    touch
 commands =
+    mkdir -p {envsitepackagesdir}/ansible/module_utils
+    touch {envsitepackagesdir}/ansible/module_utils/__init__.py
+    touch {envsitepackagesdir}/ansible/__init__.py
     bash {lsr_scriptdir}/setup_module_utils.sh
     {[lsr_config]commands_pre}
     bash -c 'if [ -d {env:RUN_PYTEST_UNIT_DIR:unit} ]; then \

--- a/tests/fixtures/test_tox_merge_ini/result.ini
+++ b/tests/fixtures/test_tox_merge_ini/result.ini
@@ -45,7 +45,7 @@ description = my local tox tests
 configfile = {lsr_configdir}/pytest.ini
 
 [testenv:py26]
-install_command = pip install {opts} {packages}
+install_command = pip install --index-url=file:///local_pypi_index/simple {opts} {packages}
 list_dependencies_command = pip freeze
 basepython = python2.6
 

--- a/tests/fixtures/test_tox_merge_ini/result.ini
+++ b/tests/fixtures/test_tox_merge_ini/result.ini
@@ -35,6 +35,8 @@ deps = py{26,27,36,37,38,39}: pytest-cov
 	localdep1
 	localdep2
 whitelist_externals = bash
+	mkdir
+	touch
 commands = localcmd1
 	localcmd2
 ignore_outcome = true


### PR DESCRIPTION
These are two changes that together with changes in

https://github.com/tyll/lsr-gh-action-py26/tree/prebuilt_image
https://github.com/tyll/network/tree/py26_test

allow to run the network role unit tests successfully against Python 2.6. Since the tox py26 test runner is broken I don't anticipate any negative impact for any other roles.
 If you can accept these changes, my next step would be to update the lsr-gh-action-py26 code to use an image in the system roles namespace at quay and once this is done and merged, I will prepare the network role PR. In the status of my fork on the network role, you can already see that the tests pass with all the changes.