### PR TITLE
add support for scraping centos download html page

### DIFF
--- a/src/tox_lsr/config_files/tox-default.ini
+++ b/src/tox_lsr/config_files/tox-default.ini
@@ -266,6 +266,7 @@ deps =
     productmd  # needed for runqemu
     PyYAML  # needed for runqemu
     ruamel.yaml  # needed for collection support
+    lxml  # needed for centoshtml support
 commands =
     python {lsr_scriptdir}/runqemu.py {posargs}
 

--- a/tests/fixtures/test_tox_merge_ini/result.ini
+++ b/tests/fixtures/test_tox_merge_ini/result.ini
@@ -221,6 +221,7 @@ setenv = {[testenv]setenv}
 deps = productmd  # needed for runqemu
 	PyYAML  # needed for runqemu
 	ruamel.yaml  # needed for collection support
+	lxml  # needed for centoshtml support
 commands = python {lsr_scriptdir}/runqemu.py {posargs}
 
 [testenv:qemu]


### PR DESCRIPTION
Instead of periodically having to scan the centos images download
page: https://cloud.centos.org/centos/9-stream/x86_64/images/
to see if a new image has been posted, this will scrape the screen
HTML looking for a new image.  This requires a new `centoshtml`
image link type.  This works sort of like the `compose` image type
which looks for a new image in a compose.
