### PR TITLE
add support for scraping centos download html page

### DIFF
--- a/src/tox_lsr/config_files/tox-default.ini
+++ b/src/tox_lsr/config_files/tox-default.ini
@@ -266,6 +266,7 @@ deps =
     productmd  # needed for runqemu
     PyYAML  # needed for runqemu
     ruamel.yaml  # needed for collection support
+    beautifulsoup4  # needed for centoshtml support
 commands =
     python {lsr_scriptdir}/runqemu.py {posargs}
 

--- a/src/tox_lsr/test_scripts/runqemu.py
+++ b/src/tox_lsr/test_scripts/runqemu.py
@@ -6,6 +6,7 @@ import errno
 import json
 import logging
 import os
+import re
 import shutil
 import subprocess  # nosec
 import sys
@@ -17,6 +18,7 @@ from distutils.util import strtobool
 
 import productmd.compose
 import yaml
+from bs4 import BeautifulSoup
 
 # https://www.freedesktop.org/wiki/CommonExtendedAttributes/
 URL_XATTR = "user.xdg.origin.url"
@@ -180,13 +182,52 @@ def composeurl2images(
     return [(composepath + qcow2[0].path) for qcow2 in candidates]
 
 
+def centoshtml2image(url, desiredarch):
+    """Find the latest image url for the CentOS Stream HTML image list."""
+    # we will need to join it with a relative path component
+    if url.endswith("/"):
+        path = url
+    else:
+        path = url + "/"
+    if path.find("/centos/9-stream/") > -1:
+        centosver = 9
+    elif path.find("/centos/8-stream/") > -1:
+        centosver = 8
+    else:
+        logging.error("Could not determine CentOS version from %s", url)
+        return ""
+
+    page = urllib.request.urlopen(url)  # nosec
+    tree = BeautifulSoup(page.read(), "html.parser")
+    imagelist = [
+        td.a["href"]
+        for td in tree.find_all("td", class_="indexcolname")
+        if td.a["href"].endswith(".qcow2")
+    ]
+    namematch = re.compile(
+        f"CentOS-Stream-GenericCloud-{centosver}-"
+        r"\([1-9][0-9]+[.][0-9]+\)"
+        f"[.]{desiredarch}[.]qcow2"
+    )
+
+    def getdatekey(imagename):
+        match = namematch.match(imagename)
+        if match and len(match.groups()) > 0:
+            return match.group(1)
+        return ""
+
+    candidate = sorted(imagelist, key=getdatekey)[-1]
+    return path + candidate
+
+
 def get_url(image):
     """Get the url to use to download the given image."""
     source = image.get("source")
+    compose_url = image.get("compose")
+    centoshtml_url = image.get("centoshtml")
     if source:
         return source
-    compose_url = image.get("compose")
-    if compose_url:
+    elif compose_url:
         variant = image.get("variant")
         image_urls = composeurl2images(compose_url, "x86_64", variant)
         if len(image_urls) == 1:
@@ -200,9 +241,13 @@ def get_url(image):
                 )
             else:
                 logging.error("no image found in compose %s", compose_url)
+    elif centoshtml_url:
+        return centoshtml2image(centoshtml_url, "x86_64")
     else:
         logging.error(
-            "neither source nor compose specified" "in image %s", image["name"]
+            "neither source nor compose nor centoshtml specified"
+            "in image %s",
+            image["name"],
         )
 
 

--- a/tests/fixtures/test_tox_merge_ini/result.ini
+++ b/tests/fixtures/test_tox_merge_ini/result.ini
@@ -221,6 +221,7 @@ setenv = {[testenv]setenv}
 deps = productmd  # needed for runqemu
 	PyYAML  # needed for runqemu
 	ruamel.yaml  # needed for collection support
+	beautifulsoup4  # needed for centoshtml support
 commands = python {lsr_scriptdir}/runqemu.py {posargs}
 
 [testenv:qemu]


### PR DESCRIPTION
Instead of periodically having to scan the centos images download
page: https://cloud.centos.org/centos/9-stream/x86_64/images/
to see if a new image has been posted, this will scrape the screen
HTML looking for a new image.  This requires a new `centoshtml`
image link type.  This works sort of like the `compose` image type
which looks for a new image in a compose.
