### PR TITLE
add support for post-snap-sleep-time, shutdown of VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,13 @@ You must provide one of `--image-file` or `--image-name`.
 * `--erase-old-snapshot` - If `true`, erase the current snapshot.  The default
   is `false`.  Use this with `--use-snapshot` to ensure a brand new snapshot is
   created.  The corresponding environment variable is `LSR_QEMU_ERASE_OLD_SNAPSHOT`.
+* `--post-snap-sleep-time` - Amount in seconds to sleep after creating the
+  snapshot. There is some sort of race condition that is highly platform
+  dependent - if you try to use the snapshot too soon after creation, you will
+  get hangs, kernel crashes, etc. in the new guest.  The only remedy so far is
+  to figure out how long to sleep after creating the snapshot. The default value
+  is `1` second.  The corresponding environment variable is
+  `LSR_QEMU_POST_SNAP_SLEEP_TIME`.
 
 Each additional command line argument is passed through to ansible-playbook, so
 it must either be an argument or a playbook.  If you want to pass both arguments


### PR DESCRIPTION
Add support for `--post-snap-sleep-time` to control the time that
the script sleeps after shutting down the VM snapshot.  The
default value is `1` second.

Ensure the VM is shutdown cleanly by using `shutdown now` to shutdown
the VM rather than just killing qemu.

This also relies on
https://pagure.io/fork/rmeggins/standard-test-roles/c/f7831911cad699b2c19db869cc9d774c60f78c0e?branch=linux-system-roles
to help ensure the filesystems are synced.
