### PR TITLE
Ensure setup_plays has tasks

### DIFF
--- a/src/tox_lsr/test_scripts/runqemu.py
+++ b/src/tox_lsr/test_scripts/runqemu.py
@@ -462,7 +462,7 @@ def make_setup_yml(
                 },
             )
 
-    if setup_plays:
+    if setup_plays or setup_play["tasks"]:
         if setup_play["tasks"]:
             setup_plays.append(setup_play)
         with open(pre_setup_yml, "w") as syf:


### PR DESCRIPTION
If not using `image` or `setup` (e.g. passing in an image_file
instead of an image_name, there will be no initial setup tasks.  If removing
cloud-init, or setting up for snapshot or yum cache, we must ensure that
setup_plays contains the setup_play.
