### PR TITLE
collection - save, force, and restore local collection

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # note 3.11 not working as of 2022-02-23 - revisit soon
-        pyver: ['2.7', '3.6', '3.8', '3.9', '3.10', '3.11']
+        # note 3.11 not working as of 2022-07-05 - revisit soon
+        pyver: ['2.7', '3.6', '3.8', '3.9', '3.10']
     steps:
       - name: checkout PR
         uses: actions/checkout@v2

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         # note 3.11 not working as of 2022-02-23 - revisit soon
-        pyver: ['2.7', '3.6', '3.8', '3.9', '3.10']
+        pyver: ['2.7', '3.6', '3.8', '3.9', '3.10', '3.11']
     steps:
       - name: checkout PR
         uses: actions/checkout@v2
@@ -28,6 +28,7 @@ jobs:
           toxpyver=$(echo "${{ matrix.pyver }}" | tr -d .)
           case "$toxpyver" in
           *-alpha*|*-beta*) toxpyver=$(echo "$toxpyver" | sed 's/^.* \([1-9][0-9]*\)$/\1/') ;;
+          27) export SAFETY_CMD="echo skipping safety" ;;
           esac
           toxpyenv="py${toxpyver}-tox30"
           # run python unit tests only on the toxenv that matches the

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ description =
 deps =
     idna<2.8 ; python_version < "2.7"
     safety ; python_version > "2.6"
+    Click<8 ; python_version < "3"
     unittest2
     pytest
     pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -18,8 +18,7 @@ description =
     {envname}: Run unit tests for {envname}
 deps =
     idna<2.8 ; python_version < "2.7"
-    safety ; python_version > "2.6"
-    Click<8 ; python_version < "3"
+    safety ; python_version >= "3"
     unittest2
     pytest
     pytest-cov


### PR DESCRIPTION
If you are developing a system role that has a dependency on
fedora.linux_system_roles, and you want to test the collection,
you have to first convert your role to a collection under .tox/
as the fedora.linux_system_roles collection.  But you may also
need to install that collection from Galaxy in order to use other
roles.  In that case, save a copy of the local converted collection,
then do a force install of fedora.linux_system_roles, then restore
the local copy of the converted collection.
