### PR TITLE
Drop support for meta/requirements.yml

### DIFF
--- a/src/tox_lsr/test_scripts/runqemu.py
+++ b/src/tox_lsr/test_scripts/runqemu.py
@@ -918,13 +918,7 @@ def run_ansible_playbooks(  # noqa: C901
 
 
 def install_requirements(sourcedir, collection_path, test_env, collection):
-    """
-    Install reqs from {meta,tests}/collection-requirements.yml, if any.
-
-    Also look for legacy meta/requirements.yml - should only be used
-    for roles, but we have been incorrectly using it for collections.
-    If found, use it and warn.
-    """
+    """Install reqs from {meta,tests}/collection-requirements.yml, if any."""
     collection_save_file = None
     force_flag = None
     if collection:
@@ -950,22 +944,10 @@ def install_requirements(sourcedir, collection_path, test_env, collection):
                 ]
             )
             force_flag = "--force"
-    legacy_rqf = os.path.join(sourcedir, "meta", "requirements.yml")
     coll_rqf = os.path.join(sourcedir, "meta", "collection-requirements.yml")
     tests_rqf = os.path.join(sourcedir, "tests", "collection-requirements.yml")
-    for reqfile in [legacy_rqf, coll_rqf, tests_rqf]:
-        # see if reqfile is in legacy role format
+    for reqfile in [coll_rqf, tests_rqf]:
         if os.path.isfile(reqfile):
-            if reqfile == legacy_rqf:
-                with open(reqfile) as rqff:
-                    obj = yaml.safe_load(rqff)
-                    if isinstance(obj, list):
-                        continue  # legacy role format
-                    logging.warning(
-                        "Using %s - please convert to %s instead",
-                        os.path.basename(reqfile),
-                        os.path.basename(coll_rqf),
-                    )
             ag_cmd = [
                 "ansible-galaxy",
                 "collection",


### PR DESCRIPTION
No repository in https://github.com/linux-system-roles has such file (`meta/collection-requirements.yml` is used), and the gluetool tool used by the linux-system-roles CI does not support it.