### PR TITLE
Add runwoke.sh for "tox -e woke" - Concious language

### DIFF
--- a/src/tox_lsr/config_files/tox-default.ini
+++ b/src/tox_lsr/config_files/tox-default.ini
@@ -4,7 +4,7 @@ envlist =
     black, pylint, flake8, yamllint
     py{26,27,36,37,38,39,310,311}, shellcheck
     collection, ansible-lint, custom
-    ansible-test
+    ansible-test, woke
 skipsdist = true
 skip_missing_interpreters = true
 
@@ -268,6 +268,11 @@ deps =
     {env:LSR_ANSIBLE_TEST_DEP:ansible-core==2.14.*}
 commands =
     bash {lsr_scriptdir}/runansible-test.sh
+
+[testenv:woke]
+changedir = {toxinidir}
+commands =
+    bash {lsr_scriptdir}/runwoke.sh
 
 [qemu_common]
 changedir = {toxinidir}

--- a/src/tox_lsr/config_files/woke.yml
+++ b/src/tox_lsr/config_files/woke.yml
@@ -1,0 +1,35 @@
+ignore_files:
+  - .tox
+  - .github
+  - .sanity-ansible-ignore-*.txt
+  - pylintrc
+
+rules:
+  - name: master
+    terms:
+      - master
+    alternatives:
+      - primary
+
+  - name: slave
+    terms:
+      - slave
+    alternatives:
+      - secondary
+
+  - name: sanity
+    terms:
+      - sanity
+    alternatives:
+      - confidence
+      - quick check
+      - coherence check
+    severity: warning
+
+  - name: dummy
+    terms:
+      - dummy
+    alternatives:
+      - placeholder
+      - sample
+    severity: warning

--- a/src/tox_lsr/test_scripts/runwoke.sh
+++ b/src/tox_lsr/test_scripts/runwoke.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT
+
+# Do not exit on an error to continue ansible-doc and ansible-test.
+set -euo pipefail
+
+#uncomment if you use $ME - otherwise set in utils.sh
+#ME=$(basename "$0")
+SCRIPTDIR=$(readlink -f "$(dirname "$0")")
+
+. "${SCRIPTDIR}/utils.sh"
+
+curl -sSfL https://git.io/getwoke | bash -s -- -b "$LSR_TOX_ENV_DIR/bin"
+WOKE_CMD="$LSR_TOX_ENV_DIR/bin/woke"
+WOKE_OUT="$LSR_TOX_ENV_DIR/tmp/woke_output.txt"
+
+"$WOKE_CMD" -c "$LSR_CONFIGDIR/woke.yml" > "$WOKE_OUT" 2>&1 || :
+
+if grep 'instead (error)' "$WOKE_OUT" 2>&1 /dev/null ; then
+  cat "$WOKE_OUT"
+  lsr_error "${ME}: Conscious language violation was reported."
+fi
+exit 0

--- a/tests/fixtures/test_tox_merge_ini/result.ini
+++ b/tests/fixtures/test_tox_merge_ini/result.ini
@@ -224,6 +224,10 @@ basepython = python3
 deps = {env:LSR_ANSIBLE_TEST_DEP:ansible-core==2.14.*}
 commands = bash {lsr_scriptdir}/runansible-test.sh
 
+[testenv:woke]
+changedir = {toxinidir}
+commands = bash {lsr_scriptdir}/runwoke.sh
+
 [qemu_common]
 changedir = {toxinidir}
 basepython = python3


### PR DESCRIPTION
This approach might be too naive to use the `woke` tool, but we could run the test locally by `tox -e woke` ~~and also via CI~~.

The script runwoke.sh installs the latest `woke` from `https://git.io/getwoke`, copies woke.yml from the config_files dir to the top level of the role to be checked, then runs `woke` using the config file. The output from woke is found in .tox/woke/tmp/woke_output.txt.

The current generated `.woke.yml` looks like this. I added `master` and `slave` to adjust to the suggested words by Red Hat.
```
ignore_files:
  - .tox
  - .github
  - .sanity-ansible-ignore-*.txt
  - pylintrc

rules:
  - name: master
    terms:
      - master
    alternatives:
      - primary

  - name: slave
    terms:
      - slave
    alternatives:
      - secondary

  - name: sanity
    terms:
      - sanity
    alternatives:
      - confidence
      - quick check
      - coherence check
    severity: warning

  - name: dummy
    terms:
      - dummy
    alternatives:
      - placeholder
      - sample
    severity: warning
```
Some questions came up in the testing...
1) For instance, to skip this error
```
CHANGELOG.md:179:57-63: `sanity` may be insensitive, use `confidence`, `quick check`, `coherence check` instead (error)
- update to tox-lsr 2.4.0 - add support for ansible-test sanity with docker
```
Is adding `// wokeignore:rule=sanity` at the end of the line acceptable?
```
-- update to tox-lsr 2.4.0 - add support for ansible-test sanity with docker
+- update to tox-lsr 2.4.0 - add support for ansible-test sanity with docker // wokeignore:rule=sanity
 - use tox-ls
```
The word `sanity` is treated as a warning.

2) There are quite a lot of words used in the products themselves (nbde_client).
E.g., a function name in the library.
```
library/nbde_client_clevis.py:1435:13-19: `sanity` may be insensitive, use `confidence`, `quick check`, `coherence check` instead (error)
def bindings_sanity_check(bindings, data_dir, check_mode):
             ^
```
Another example of using `Master` is in the config param (ssh).
```
tests/tests_global_config.yml:21:17-23: `Master` may be insensitive, use `primary` instead (error)
          ControlMaster: auto
                 ^
```
What we should do to workaround these errors? Shall we set `severity: warning` to `master` and `sanity` and leave them as they are?

The word `sanity` is treated as a warning.