### PR TITLE
require tox 3.x for now; default to ansible-lint 5.x

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -5,18 +5,29 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   python:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        # note 3.11 not working as of 2022-07-05 - revisit soon
-        pyver: ['2.7', '3.6', '3.8', '3.9', '3.10']
+        pyver_os:
+          - ver: '2.7'
+            os: ubuntu-20.04
+          - ver: '3.6'
+            os: ubuntu-20.04
+          - ver: '3.8'
+            os: ubuntu-latest
+          - ver: '3.9'
+            os: ubuntu-latest
+          - ver: '3.10'
+            os: ubuntu-latest
+          - ver: '3.11'
+            os: ubuntu-latest
+    runs-on: ${{ matrix.pyver_os.os }}
     steps:
       - name: checkout PR
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.pyver }}
+          python-version: ${{ matrix.pyver_os.ver }}
       - name: Install platform dependencies, python, tox
         run: |
           set -euxo pipefail
@@ -25,7 +36,7 @@ jobs:
       - name: Run tox tests
         run: |
           set -euxo pipefail
-          toxpyver=$(echo "${{ matrix.pyver }}" | tr -d .)
+          toxpyver=$(echo "${{ matrix.pyver_os.ver }}" | tr -d .)
           case "$toxpyver" in
           *-alpha*|*-beta*) toxpyver=$(echo "$toxpyver" | sed 's/^.* \([1-9][0-9]*\)$/\1/') ;;
           27) export SAFETY_CMD="echo skipping safety" ;;
@@ -38,7 +49,7 @@ jobs:
     runs-on: ubuntu-16.04
     steps:
       - name: checkout PR
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install python, dependencies
         run: |
           set -euo pipefail

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ zip_safe = False
 setup_requires =
     setuptools >=40.9.0
 install_requires =
-    tox
+    tox<4
 python_requires = >=2.6, <4
 #include_package_data = True
 packages = find:

--- a/setup.py
+++ b/setup.py
@@ -43,5 +43,5 @@ setup(
         "tox": ["lsr = tox_lsr.hooks"],
     },
     python_requires=">=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
-    install_requires=["tox", "configparser"],
+    install_requires=["tox<4", "configparser"],
 )

--- a/src/tox_lsr/config_files/tox-default.ini
+++ b/src/tox_lsr/config_files/tox-default.ini
@@ -245,7 +245,7 @@ configfile = {lsr_configdir}/ansible-lint.yml
 changedir = {toxinidir}
 deps =
     {env:LSR_ANSIBLE_LINT_DEP:ansible-core==2.14.*}
-    ansible-lint=={env:LSR_ANSIBLE_LINT_VER:6.*}
+    ansible-lint=={env:LSR_ANSIBLE_LINT_VER:5.*}
 commands_pre =
     bash {lsr_scriptdir}/ansible-lint-helper.sh pre
 commands =

--- a/tests/fixtures/test_tox_merge_ini/result.ini
+++ b/tests/fixtures/test_tox_merge_ini/result.ini
@@ -208,7 +208,7 @@ configfile = {lsr_configdir}/ansible-lint.yml
 [testenv:ansible-lint]
 changedir = {toxinidir}
 deps = {env:LSR_ANSIBLE_LINT_DEP:ansible-core==2.14.*}
-	ansible-lint=={env:LSR_ANSIBLE_LINT_VER:6.*}
+	ansible-lint=={env:LSR_ANSIBLE_LINT_VER:5.*}
 commands_pre = bash {lsr_scriptdir}/ansible-lint-helper.sh pre
 commands = bash {lsr_scriptdir}/setup_module_utils.sh
 	{[lsr_config]commands_pre}

--- a/tox.ini
+++ b/tox.ini
@@ -68,6 +68,7 @@ deps =
     tox
     unittest2
     pylint
+    py
 commands =
     pylint setup.py src/tox_lsr
     pylint -d C0115,C0116,C0321,E0611,R0903,W0613 \

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ deps =
     tox20: tox==2.4
     py{26,27}: mock
 commands =
-    {env:SAFETY_CMD:safety} check -i 47833 -i 42559 -i 42218 -i 40291 -i 38765 -i 39611 -i 44492 --full-report  # ignore pip, PyYAML problems
+    {env:SAFETY_CMD:safety} check -i 47833 -i 42559 -i 42218 -i 40291 -i 38765 -i 39611 -i 44492 -i 51457 -i 51499 --full-report  # ignore pip, PyYAML problems
     pytest --cov=tox_lsr --cov-report=term-missing tests
     {env:COVERALLS_CMD:coveralls --output={envname}-coverage.txt}
 


### PR DESCRIPTION
We will need to convert tox-lsr to use tox 4.x.  This is not trivial.
In the meantime, use tox 3.x for tox-lsr.
Revert the default for ansible-lint from 6.x to 5.x so as not to
break lots of roles with this update.
