### PR TITLE
use official Ansible container for ansible-lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,6 @@ The following is an example of a `tox.ini` from the kernel_settings role:
 lsr_enable = true
 commands_pre = bash -c '{toxinidir}/tests/install_tuned_for_testing.sh || {toxinidir}/tests/kernel_settings/install_tuned_for_testing.sh'
 
-[lsr_ansible-lint]
-configfile = {toxinidir}/.ansible-lint
-
 [lsr_yamllint]
 configfile = {toxinidir}/.yamllint.yml
 configbasename = .yamllint.yml
@@ -321,10 +318,6 @@ environment variables:
 * `RUN_YAMLLINT_CONFIG_FILE` - path to config file to use instead of the default
 * `LSR_ANSIBLE_TEST_DOCKER` - if set to `true`, `ansible-test` will be run with
   `--docker`
-* `LSR_ANSIBLE_LINT_DEP` - this is the dep to pass when doing the pip install of
-  ansible for ansible-lint.  The default is `ansible-core==2.12.*`.
-* `LSR_ANSIBLE_LINT_VER` - this is the version of ansible-lint to install for
-  the ansible-lint testenv.  The default is `5.2.0`.
 * `LSR_ANSIBLE_TEST_DEP` - this is the dep to pass when doing the pip install of
   ansible for ansible-test.  The default is `ansible-core==2.12.*`.
 * `LSR_PYLINT_ANSIBLE_DEP` - this is the dep to pass when doing the pip install of

--- a/README.md
+++ b/README.md
@@ -247,9 +247,8 @@ Then doing `tox -e flake8` would use your flake8.conf.
 
 ### Using setenv and environment variables
 
-These environment variables can be set in your local tox.ini `testenv` section,
-or in your CI configuration e.g. `.github/workflows/tox.yml`.  Some of the
-environment variables we used in the old scripts are carried over:
+These environment variables can be set in your local tox.ini `testenv` section.
+Some of the environment variables we used in the old scripts are carried over:
 * `RUN_PYTEST_SETUP_MODULE_UTILS` - if set to an arbitrary non-empty value, the
   environment will be configured so that tests of the `module_utils/` code will be
   run correctly
@@ -262,22 +261,6 @@ environment variables we used in the old scripts are carried over:
   `--ignore=some,errs`
 * `RUN_BLACK_EXTRA_ARGS` - any extra command line arguments to provide e.g.
   `--ignore=some,errs`
-* `LSR_EXTRA_PACKAGES` - set in `.github/workflows/tox.yml` - list of extra
-  packages to install in the CI environment (typically an Ubuntu variant)
-* `LSR_ANSIBLES` - set in `.github/workflows/tox.yml` - ansible versions to test
-  molecule against in the form that is used with pip e.g. use
-  `LSR_ANSIBLES='ansible==2.8.* ansible==2.9.*'` to use ansible 2.8 and ansible
-  2.9.  Only ansible 2.8 and higher are supported. tox-lsr 2.0 uses molecule v3,
-  which does not work with ansible 2.7 or earlier.
-* `LSR_MSCENARIOS` - set in `.github/workflows/tox.yml` - molecule scenarios to
-  test
-* `LSR_MOLECULE_DRIVER` - default `docker` - The molecule driver to use.  If you
-  want to use `podman`, use `LSR_MOLECULE_DRIVER=podman`
-* `LSR_MOLECULE_DRIVER_VERSION` - default empty - use this if you want to
-  override the version of the molecule driver pypi package - otherwise, the
-  correct version will be auto-detected.  E.g.
-  `LSR_MOLECULE_DRIVER=podman LSR_MOLECULE_DRIVER_VERSION='<4.4'` will evaluate
-  to something like `pip install podman<4.4`
 * `LSR_PUBLISH_COVERAGE` - If the variable is unset or empty (the default), no
   coverage is published.  Other valid values for the variable are:
     * `strict` - the reporting is performed in strict mode, so situations like
@@ -324,6 +307,25 @@ environment variables:
   ansible for pylint.  The default is `ansible-core==2.12.*`.
 * `LSR_RUN_TEST_DIR` - this is the directory to use to override `changedir`, for
   those tests that need it, primarily the tests run "recursively" via `-e collection`
+* `LSR_CONTAINER_RUNTIME` - default `podman` - set to `docker` if you must
+
+These environment variables are deprecated and will be removed soon:
+* `LSR_EXTRA_PACKAGES` - set in `.github/workflows/tox.yml` - list of extra
+  packages to install in the CI environment (typically an Ubuntu variant)
+* `LSR_ANSIBLES` - set in `.github/workflows/tox.yml` - ansible versions to test
+  molecule against in the form that is used with pip e.g. use
+  `LSR_ANSIBLES='ansible==2.8.* ansible==2.9.*'` to use ansible 2.8 and ansible
+  2.9.  Only ansible 2.8 and higher are supported. tox-lsr 2.0 uses molecule v3,
+  which does not work with ansible 2.7 or earlier.
+* `LSR_MSCENARIOS` - set in `.github/workflows/tox.yml` - molecule scenarios to
+  test
+* `LSR_MOLECULE_DRIVER` - default `docker` - The molecule driver to use.  If you
+  want to use `podman`, use `LSR_MOLECULE_DRIVER=podman`
+* `LSR_MOLECULE_DRIVER_VERSION` - default empty - use this if you want to
+  override the version of the molecule driver pypi package - otherwise, the
+  correct version will be auto-detected.  E.g.
+  `LSR_MOLECULE_DRIVER=podman LSR_MOLECULE_DRIVER_VERSION='<4.4'` will evaluate
+  to something like `pip install podman<4.4`
 
 These environment variables have been removed:
 * `RUN_PYLINT_INCLUDE` - use `RUN_PYLINT_EXTRA_ARGS`

--- a/src/tox_lsr/config_files/ansible-lint.yml
+++ b/src/tox_lsr/config_files/ansible-lint.yml
@@ -1,3 +1,0 @@
----
-skip_list:
-- role-name

--- a/src/tox_lsr/config_files/tox-default.ini
+++ b/src/tox_lsr/config_files/tox-default.ini
@@ -238,23 +238,21 @@ commands =
     bash {lsr_scriptdir}/runshellcheck.sh
     {[lsr_config]commands_post}
 
-[lsr_ansible-lint]
-configfile = {lsr_configdir}/ansible-lint.yml
-
 [testenv:ansible-lint]
 changedir = {toxinidir}
-deps =
-    {env:LSR_ANSIBLE_LINT_DEP:ansible-core==2.14.*}
-    ansible-lint=={env:LSR_ANSIBLE_LINT_VER:5.*}
+whitelist_externals =
+    podman
+    bash
 commands_pre =
     bash {lsr_scriptdir}/ansible-lint-helper.sh pre
 commands =
     bash {lsr_scriptdir}/setup_module_utils.sh
     {[lsr_config]commands_pre}
-    ansible-lint -v --exclude=tests/roles --exclude=.github \
-        --exclude=.yamllint.yml \
-        -c {[lsr_ansible-lint]configfile} \
-        {env:RUN_ANSIBLE_LINT_EXTRA_ARGS:} {posargs}
+    {env:LSR_CONTAINER_RUNTIME:podman} run --rm --privileged \
+      -v {toxinidir}:/workdir --workdir /workdir \
+      --entrypoint /usr/local/bin/ansible-lint \
+      quay.io/ansible/creator-ee:v0.9.5 \
+      {env:RUN_ANSIBLE_LINT_EXTRA_ARGS:} {posargs}
     {[lsr_config]commands_post}
 commands_post =
     bash {lsr_scriptdir}/ansible-lint-helper.sh post

--- a/tests/fixtures/test_tox_merge_ini/result.ini
+++ b/tests/fixtures/test_tox_merge_ini/result.ini
@@ -202,19 +202,17 @@ commands = bash {lsr_scriptdir}/setup_module_utils.sh
 	bash {lsr_scriptdir}/runshellcheck.sh
 	{[lsr_config]commands_post}
 
-[lsr_ansible-lint]
-configfile = {lsr_configdir}/ansible-lint.yml
-
 [testenv:ansible-lint]
 changedir = {toxinidir}
-deps = {env:LSR_ANSIBLE_LINT_DEP:ansible-core==2.14.*}
-	ansible-lint=={env:LSR_ANSIBLE_LINT_VER:5.*}
+whitelist_externals = podman
+	bash
 commands_pre = bash {lsr_scriptdir}/ansible-lint-helper.sh pre
 commands = bash {lsr_scriptdir}/setup_module_utils.sh
 	{[lsr_config]commands_pre}
-	ansible-lint -v --exclude=tests/roles --exclude=.github \
-	--exclude=.yamllint.yml \
-	-c {[lsr_ansible-lint]configfile} \
+	{env:LSR_CONTAINER_RUNTIME:podman} run --rm --privileged \
+	-v {toxinidir}:/workdir --workdir /workdir \
+	--entrypoint /usr/local/bin/ansible-lint \
+	quay.io/ansible/creator-ee:v0.9.5 \
 	{env:RUN_ANSIBLE_LINT_EXTRA_ARGS:} {posargs}
 	{[lsr_config]commands_post}
 commands_post = bash {lsr_scriptdir}/ansible-lint-helper.sh post


### PR DESCRIPTION
Basically, run ansible-lint locally the same way that the ansible-lint
github action runs.  This helps when you get errors in the github CI,
you can reproduce and fix locally.

https://github.com/ansible/ansible-lint-action/blob/main/action.yml#L24

Get rid of the lsr_ansible-lint configuration.  If you want to configure
ansible-lint, you specify .ansible-lint in the role repo root directory.
This also helps simplify and make the local action work just like the
github action.

By default, it will use podman to run the container.  You can set
`LSR_CONTAINER_RUNTIME` to use a different runtime.

You can pass extra command line arguments to ansible-lint like this:
`tox -e ansible-lint -- -vvv --exclude=my/dir/ ...`
