### PR TITLE
Woke skips checking files whose filename contains master in templates.

### DIFF
--- a/src/tox_lsr/config_files/woke.yml
+++ b/src/tox_lsr/config_files/woke.yml
@@ -5,6 +5,7 @@ ignore_files:
   - pylintrc
   - vendor
   - tests/sanity
+  - templates/*master*
 
 rules:
   - name: master


### PR DESCRIPTION
Templates often generate configuration files whose name is determined by the system. E.g., timemaster.conf.j2 in timestamp.