### PR TITLE
codeql - remove codeql database before initializing it.

### DIFF
--- a/src/tox_lsr/test_scripts/runcodeql.sh
+++ b/src/tox_lsr/test_scripts/runcodeql.sh
@@ -66,6 +66,9 @@ sed -e "s/pip install --user/pip install/" \
 $CODEQLACTIONDIR/python-setup/install_tools.sh > "$LSR_TOX_ENV_TMP_DIR/install_tools.sh"
 bash "$LSR_TOX_ENV_TMP_DIR/install_tools.sh"
 
+if [ -d "$DBDIR/python" ]; then
+    rm -rf $DBDIR/*
+fi
 codeql database init --db-cluster "$DBDIR" --source-root="$TOPDIR" \
     --language=python
 


### PR DESCRIPTION
If the database already exists, the next run fails with a database exists error.
