### PR TITLE
pytest: Create xml coverage report for codecov

### DIFF
--- a/src/tox_lsr/config_files/tox-default.ini
+++ b/src/tox_lsr/config_files/tox-default.ini
@@ -49,6 +49,7 @@ commands =
         python -m pytest -c {[lsr_pytest]configfile} --durations=5 \
         --cov={toxinidir}/library --cov={toxinidir}/module_utils \
         --cov-report=html:htmlcov-{envname} \
+        --cov-report=xml:coverage-{envname}.xml \
         --cov-report=term {env:RUN_PYTEST_EXTRA_ARGS:} {posargs} {env:RUN_PYTEST_UNIT_DIR:unit} ; \
         fi'
     {[lsr_config]commands_post}


### PR DESCRIPTION
Create the XML coverage report since this is the one that is needed for codecov.

Note: codecov uses some heuristics to find the coverage file and it does not seem to be possible to specify which file to use. The get_coverage.yml playbook is also wrongly identified as a coverage report which can be confusing if the actual report is not identified as one.

Signed-off-by: Till Maas <opensource@till.name>

https://app.codecov.io/github/linux-system-roles/network/commit/4a5122e94ca922813c7eadfd19568b338794b023 contains a successful run for the Python 3.11 job for reference.
Btw. maybe the coveralls support can be dropped from tox_lsr, not sure if anyone else is using it.

Remark: The current codecov reports seem to be only based on the ansible-test job results and are therefore very basic.