### PR TITLE
update ansible-lint to use latest Ansible creator EE image 0.15

### DIFF
--- a/src/tox_lsr/config_files/tox-default.ini
+++ b/src/tox_lsr/config_files/tox-default.ini
@@ -252,7 +252,7 @@ commands =
     {env:LSR_CONTAINER_RUNTIME:podman} run --rm --privileged \
       -v {toxinidir}:/workdir --workdir /workdir \
       --entrypoint /usr/local/bin/ansible-lint \
-      quay.io/ansible/creator-ee:v0.13.0 \
+      quay.io/ansible/creator-ee:v0.15.0 \
       {env:RUN_ANSIBLE_LINT_EXTRA_ARGS:} {posargs}
     {[lsr_config]commands_post}
 commands_post =

--- a/tests/fixtures/test_tox_merge_ini/result.ini
+++ b/tests/fixtures/test_tox_merge_ini/result.ini
@@ -212,7 +212,7 @@ commands = bash {lsr_scriptdir}/setup_module_utils.sh
 	{env:LSR_CONTAINER_RUNTIME:podman} run --rm --privileged \
 	-v {toxinidir}:/workdir --workdir /workdir \
 	--entrypoint /usr/local/bin/ansible-lint \
-	quay.io/ansible/creator-ee:v0.13.0 \
+	quay.io/ansible/creator-ee:v0.15.0 \
 	{env:RUN_ANSIBLE_LINT_EXTRA_ARGS:} {posargs}
 	{[lsr_config]commands_post}
 commands_post = bash {lsr_scriptdir}/ansible-lint-helper.sh post


### PR DESCRIPTION
update ansible-lint to use latest Ansible creator EE image 0.15
add `selinux` dependency for qemu to fix some tests
