### PR TITLE
test: remove-cloud-init - do not remove libselinux-python

### DIFF
--- a/src/tox_lsr/test_scripts/runqemu.py
+++ b/src/tox_lsr/test_scripts/runqemu.py
@@ -376,6 +376,7 @@ def make_setup_yml(
                         "__cloud_init_reqs is success",
                         "item.1.stdout is match('no package requires ')",
                         "not item.0 is match('^procps')",
+                        "not item.0 is match('^libselinux-python')",
                     ],  # noqa: E501
                     "ignore_errors": True,
                     "no_log": no_log,


### PR DESCRIPTION
When using `--remove-cloud-init`, do not remove `libselinux-python`
which is needed by Ansible itself on EL6 with python 2.6.
