### PR TITLE
add markdownlint testenv

### DIFF
--- a/src/tox_lsr/config_files/tox-default.ini
+++ b/src/tox_lsr/config_files/tox-default.ini
@@ -431,3 +431,22 @@ deps =
     PyYAML
 commands =
     python {lsr_scriptdir}/check_meta_versions.py {posargs}
+
+[testenv:markdownlint]
+changedir = {toxinidir}
+whitelist_externals = podman
+    bash
+    cat
+    rm
+setenv =
+    {[testenv]setenv}
+    GITHUB_OUTPUT = /tmp/mdl.log
+    INPUT_PATH = .
+commands = bash {lsr_scriptdir}/setup_module_utils.sh
+    {[lsr_config]commands_pre}
+    {env:LSR_CONTAINER_RUNTIME:podman} run --rm --privileged \
+      -v {toxinidir}:/workdir --workdir /workdir \
+      -e GITHUB_OUTPUT -e INPUT_PATH \
+      ghcr.io/actionshub/markdownlint:v3.1.3 \
+      {env:RUN_MARKDOWNLINT_EXTRA_ARGS:} {posargs}
+    {[lsr_config]commands_post}

--- a/tests/fixtures/test_tox_merge_ini/result.ini
+++ b/tests/fixtures/test_tox_merge_ini/result.ini
@@ -344,6 +344,24 @@ setenv = {[testenv]setenv}
 deps = PyYAML
 commands = python {lsr_scriptdir}/check_meta_versions.py {posargs}
 
+[testenv:markdownlint]
+changedir = {toxinidir}
+whitelist_externals = podman
+	bash
+	cat
+	rm
+setenv = {[testenv]setenv}
+	GITHUB_OUTPUT = /tmp/mdl.log
+	INPUT_PATH = .
+commands = bash {lsr_scriptdir}/setup_module_utils.sh
+	{[lsr_config]commands_pre}
+	{env:LSR_CONTAINER_RUNTIME:podman} run --rm --privileged \
+	-v {toxinidir}:/workdir --workdir /workdir \
+	-e GITHUB_OUTPUT -e INPUT_PATH \
+	ghcr.io/actionshub/markdownlint:v3.1.3 \
+	{env:RUN_MARKDOWNLINT_EXTRA_ARGS:} {posargs}
+	{[lsr_config]commands_post}
+
 [custom_common]
 setenv = CUSTOMCOMMON = customcommon
 commands = customcommoncmd


### PR DESCRIPTION
Add `markdownlint` testenv. This uses the github action image, similar
to how the `ansible-lint` testenv works.  This should make it easier
to add a markdownlint github action check.

NOTE: Still missing support for a markdownlint config file.  I'll note
that the network role has a customized .mdl that might not be suitable
for general purpose use.
