### PR TITLE
use allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ You can use the standard `tox` configuration in your local `tox.ini`, and the
 plugin will attempt to merge those settings with its default settings.  If the
 setting is set in the local `tox.ini`, it will be applied, replacing any default
 setting, if any.  However, there are a few settings which will be merged -
-`setenv`, `passenv`, `deps`, `whitelist_external`.  For `setenv`, you can
+`setenv`, `passenv`, `deps`, `allowlist_external`.  For `setenv`, you can
 override a default setting.  For example, if the default was:
 ```ini
 [testenv:pylint]
@@ -113,7 +113,7 @@ deps =
     b
 passenv =
     A
-whitelist_externals =
+allowlist_externals =
     bash
 commands = pylint ...
 ```
@@ -128,7 +128,7 @@ deps =
     d
 passenv =
     B
-whitelist_externals =
+allowlist_externals =
     sed
     grep
 commands = mypylint
@@ -148,7 +148,7 @@ deps =
 passenv =
     A
     B
-whitelist_externals =
+allowlist_externals =
     bash
     sed
     grep

--- a/src/tox_lsr/config_files/tox-default.ini
+++ b/src/tox_lsr/config_files/tox-default.ini
@@ -374,10 +374,7 @@ whitelist_externals =
     grep
     echo
     bash
-commands =
-    bash -c 'grep -EIlr -e "\{\{ ansible_managed \}\}" -e "# \{\{ ansible_managed" ./* && \
-      echo "In the above files, the ansible_managed variable must be commented with \"\{\{ ansible_managed | comment \}\}\" as described in https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#manipulating-text" && \
-      exit 1 || exit 0'
+commands = bash {lsr_scriptdir}/check-ansible-managed.sh
 
 [container_common]
 changedir = {toxinidir}

--- a/src/tox_lsr/config_files/tox-default.ini
+++ b/src/tox_lsr/config_files/tox-default.ini
@@ -3,7 +3,7 @@
 envlist =
     black, pylint, flake8, yamllint
     py{26,27,36,37,38,39,310,311}, shellcheck
-    collection, ansible-lint, custom
+    collection, ansible-lint
     ansible-test, woke, codeql, commitlint
 skipsdist = true
 skip_missing_interpreters = true
@@ -35,7 +35,7 @@ deps =
     py{27,36,37,38,39,310,311}: pytest>=3.5.1
     py26: pytest
     py{26,27,36,37,38,39,310,311}: -rpytest_extra_requirements.txt
-whitelist_externals =
+allowlist_externals =
     bash
     mkdir
     touch
@@ -151,7 +151,7 @@ commands =
     {[lsr_yamllint]commands_pre}
     yamllint -c {env:RUN_YAMLLINT_CONFIG_FILE:{envtmpdir}/{[lsr_yamllint]configbasename}} {env:RUN_YAMLLINT_EXTRA_ARGS:} {posargs} .
     {[lsr_config]commands_post}
-whitelist_externals =
+allowlist_externals =
     bash
     cp
     sed
@@ -223,13 +223,6 @@ deps =
 commands =
     bash {lsr_scriptdir}/runcollection.sh {env:LSR_ROLE2COLL_VERSION:master}
 
-[testenv:custom]
-changedir = {toxinidir}
-deps =
-    -rcustom_requirements.txt
-commands =
-    bash -c 'if [ -f {toxinidir}/.travis/custom.sh ]; then bash {toxinidir}/.travis/custom.sh; fi'
-
 [testenv:shellcheck]
 changedir = {env:LSR_RUN_TEST_DIR:{toxinidir}}
 envdir = {toxworkdir}/env-shellcheck
@@ -241,7 +234,7 @@ commands =
 
 [testenv:ansible-lint]
 changedir = {toxinidir}
-whitelist_externals =
+allowlist_externals =
     podman
     bash
 commands_pre =
@@ -353,10 +346,21 @@ deps =
 commands =
     {[qemu_common]commands}
 
+[testenv:qemu-ansible-core-2.15]
+changedir = {[qemu_common]changedir}
+basepython = {[qemu_common]basepython}
+setenv =
+    {[qemu_common]setenv}
+deps =
+    {[qemu_common]deps}
+    ansible-core==2.15.*
+commands =
+    {[qemu_common]commands}
+
 [testenv:ansible-plugin-scan]
 changedir = {env:LSR_RUN_TEST_DIR:{toxinidir}}
 basepython = python3
-whitelist_externals =
+allowlist_externals =
     curl
     bash
 deps =
@@ -370,7 +374,7 @@ commands =
 [testenv:ansible-managed-var-comment]
 changedir = {toxinidir}
 basepython = python3
-whitelist_externals =
+allowlist_externals =
     grep
     echo
     bash
@@ -425,19 +429,19 @@ deps =
 commands =
     {[container_common]commands}
 
-[testenv:check-meta-versions]
-changedir = {toxinidir}
-basepython = python3
+[testenv:container-ansible-core-2.15]
+changedir = {[container_common]changedir}
+basepython = {[container_common]basepython}
 setenv =
-    {[testenv]setenv}
+    {[container_common]setenv}
 deps =
-    PyYAML
+    ansible-core==2.15.*
 commands =
-    python {lsr_scriptdir}/check_meta_versions.py {posargs}
+    {[container_common]commands}
 
 [testenv:markdownlint]
 changedir = {toxinidir}
-whitelist_externals = podman
+allowlist_externals = podman
     bash
     cat
     rm

--- a/src/tox_lsr/hooks3.py
+++ b/src/tox_lsr/hooks3.py
@@ -130,9 +130,9 @@ def merge_prop_values(propname, envconf, def_envconf):
         envconf.deps = list(set(envconf.deps + def_envconf.deps))
     elif propname == "passenv":
         envconf.passenv = envconf.passenv.union(def_envconf.passenv)
-    elif propname == "whitelist_externals":
-        envconf.whitelist_externals = list(
-            set(envconf.whitelist_externals + def_envconf.whitelist_externals)
+    elif propname == "allowlist_externals":
+        envconf.allowlist_externals = list(
+            set(envconf.allowlist_externals + def_envconf.allowlist_externals)
         )
 
 
@@ -140,7 +140,7 @@ def set_prop_values_ini(propname, def_conf, conf):
     # type: (str, MutableMapping[str, str], MutableMapping[str, str]) -> None
     """If propname is one of the values we can merge, do the merge."""
 
-    can_be_merged = set(["setenv", "deps", "passenv", "whitelist_externals"])
+    can_be_merged = set(["setenv", "deps", "passenv", "allowlist_externals"])
     conf_val = conf[propname]
     if propname not in def_conf:
         def_conf[propname] = conf_val

--- a/src/tox_lsr/hooks4.py
+++ b/src/tox_lsr/hooks4.py
@@ -79,7 +79,7 @@ configuration, usually in tox.ini file, in the following way:
 1. For every pair (section, key) in tox-default.ini:
    * if (section, key) is not in tox.ini:
      * interpolate the value and add it to tox.ini under (section, key);
-   * otherwise, if key is one of deps, setenv, passenv or whitelist_externals:
+   * otherwise, if key is one of deps, setenv, passenv or allowlist_externals:
      * add the default value before the user-specific value and interpolate the
        entire result;
    * otherwise, interpolate the user-specific value.
@@ -199,7 +199,7 @@ def inject_defaults(config, default_config):
     For every (section, key) in tox-default.ini:
     * if (section, key) is not in tox.ini, add it and interpolate
     * otherwise, if key is one of setenv, deps, passenv, or
-      whitelist_externals:
+      allowlist_externals:
       * insert the value from tox-default.ini before the value from tox.ini and
         interpolate
     * otherwise, only interpolate
@@ -228,7 +228,7 @@ def inject_defaults(config, default_config):
                 config.set(
                     section, key, lsr_interpolate(value, scripts, configs)
                 )
-            elif key in ("setenv", "deps", "passenv", "whitelist_externals"):
+            elif key in ("setenv", "deps", "passenv", "allowlist_externals"):
                 value += "\n" + config.get(section, key)
                 config.set(
                     section, key, lsr_interpolate(value, scripts, configs)

--- a/src/tox_lsr/test_scripts/check-ansible-managed.sh
+++ b/src/tox_lsr/test_scripts/check-ansible-managed.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -euo pipefail
+
+#uncomment if you use $ME - otherwise set in utils.sh
+#ME=$(basename "$0")
+SCRIPTDIR=$(readlink -f "$(dirname "$0")")
+
+. "${SCRIPTDIR}/utils.sh"
+
+if grep -EIlr -e "{{ ansible_managed }}" -e "# {{ ansible_managed" ./*; then
+  echo In the above files, the ansible_managed variable must be commented with '"{{ ansible_managed | comment }}"' as described in https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#manipulating-text
+  exit 1
+fi

--- a/stubs/tox/config/__init__.pyi
+++ b/stubs/tox/config/__init__.pyi
@@ -56,7 +56,7 @@ class TestenvConfig(object):
     factors: Set[str]
     deps: List[str]
     passenv: Set[str]
-    whitelist_externals: List[str]
+    allowlist_externals: List[str]
 
 class Config(object):  # noqa: H238
     # tox 4

--- a/tests/fixtures/test_tox_merge_ini/result.ini
+++ b/tests/fixtures/test_tox_merge_ini/result.ini
@@ -303,9 +303,7 @@ basepython = python3
 whitelist_externals = grep
 	echo
 	bash
-commands = bash -c 'grep -EIlr -e "\{\{ ansible_managed \}\}" -e "# \{\{ ansible_managed" ./* && \
-	echo "In the above files, the ansible_managed variable must be commented with \"\{\{ ansible_managed | comment \}\}\" as described in https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#manipulating-text" && \
-	exit 1 || exit 0'
+commands = bash {lsr_scriptdir}/check-ansible-managed.sh
 
 [container_common]
 changedir = {toxinidir}

--- a/tests/fixtures/test_tox_merge_ini/result.ini
+++ b/tests/fixtures/test_tox_merge_ini/result.ini
@@ -34,7 +34,7 @@ deps = py{26,27,36,37,38,39,310,311}: pytest-cov
 	py{26,27,36,37,38,39,310,311}: -rpytest_extra_requirements.txt
 	localdep1
 	localdep2
-whitelist_externals = bash
+allowlist_externals = bash
 	mkdir
 	touch
 commands = localcmd1
@@ -132,7 +132,7 @@ commands = bash -c 'test -d {envtmpdir} || mkdir -p {envtmpdir}'
 	{[lsr_yamllint]commands_pre}
 	yamllint -c {env:RUN_YAMLLINT_CONFIG_FILE:{envtmpdir}/{[lsr_yamllint]configbasename}} {env:RUN_YAMLLINT_EXTRA_ARGS:} {posargs} .
 	{[lsr_config]commands_post}
-whitelist_externals = bash
+allowlist_externals = bash
 	cp
 	sed
 
@@ -186,14 +186,6 @@ deps = jmespath
 	ruamel.yaml
 commands = bash {lsr_scriptdir}/runcollection.sh {env:LSR_ROLE2COLL_VERSION:master}
 
-[testenv:custom]
-changedir = {toxinidir}
-deps = -rcustom_requirements.txt
-	override_custom_deps1
-	override_custom_deps2
-commands = override_custom_cmd
-setenv = OVERRIDE_CUSTOM = override_custom
-
 [testenv:shellcheck]
 changedir = {env:LSR_RUN_TEST_DIR:{toxinidir}}
 envdir = {toxworkdir}/env-shellcheck
@@ -204,7 +196,7 @@ commands = bash {lsr_scriptdir}/setup_module_utils.sh
 
 [testenv:ansible-lint]
 changedir = {toxinidir}
-whitelist_externals = podman
+allowlist_externals = podman
 	bash
 commands_pre = bash {lsr_scriptdir}/ansible-lint-helper.sh pre
 commands = bash {lsr_scriptdir}/setup_module_utils.sh
@@ -286,10 +278,18 @@ deps = {[qemu_common]deps}
 	ansible-core==2.14.*
 commands = {[qemu_common]commands}
 
+[testenv:qemu-ansible-core-2.15]
+changedir = {[qemu_common]changedir}
+basepython = {[qemu_common]basepython}
+setenv = {[qemu_common]setenv}
+deps = {[qemu_common]deps}
+	ansible-core==2.15.*
+commands = {[qemu_common]commands}
+
 [testenv:ansible-plugin-scan]
 changedir = {env:LSR_RUN_TEST_DIR:{toxinidir}}
 basepython = python3
-whitelist_externals = curl
+allowlist_externals = curl
 	bash
 deps = ansible==6.*
 	jinja2==2.7.* ; python_version <= "3.7"
@@ -300,7 +300,7 @@ commands = curl -L -o {envdir}/report-modules-plugins.py https://raw.githubuserc
 [testenv:ansible-managed-var-comment]
 changedir = {toxinidir}
 basepython = python3
-whitelist_externals = grep
+allowlist_externals = grep
 	echo
 	bash
 commands = bash {lsr_scriptdir}/check-ansible-managed.sh
@@ -340,16 +340,16 @@ setenv = {[container_common]setenv}
 deps = ansible-core==2.14.*
 commands = {[container_common]commands}
 
-[testenv:check-meta-versions]
-changedir = {toxinidir}
-basepython = python3
-setenv = {[testenv]setenv}
-deps = PyYAML
-commands = python {lsr_scriptdir}/check_meta_versions.py {posargs}
+[testenv:container-ansible-core-2.15]
+changedir = {[container_common]changedir}
+basepython = {[container_common]basepython}
+setenv = {[container_common]setenv}
+deps = ansible-core==2.15.*
+commands = {[container_common]commands}
 
 [testenv:markdownlint]
 changedir = {toxinidir}
-whitelist_externals = podman
+allowlist_externals = podman
 	bash
 	cat
 	rm
@@ -376,4 +376,10 @@ setenv = {[custom_common]setenv}
 deps = {[custom_common]deps}
 suicide_timeout = 10.0
 description = mycustom1
+
+[testenv:custom]
+setenv = OVERRIDE_CUSTOM = override_custom
+commands = override_custom_cmd
+deps = override_custom_deps1
+	override_custom_deps2
 

--- a/tests/unit/test_hooks3.py
+++ b/tests/unit/test_hooks3.py
@@ -190,19 +190,19 @@ class HooksTestCase(TestCase):
         # test empty tec
         tec = MagicMock()
         def_tec = MagicMock()
-        propnames = ["setenv", "deps", "passenv", "whitelist_externals"]
+        propnames = ["setenv", "deps", "passenv", "allowlist_externals"]
         empty_attrs = {
             "setenv": {},
             "deps": [],
             "passenv": set(),
-            "whitelist_externals": [],
+            "allowlist_externals": [],
         }
         tec.configure_mock(**deepcopy(empty_attrs))
         full_attrs = {
             "setenv": {"a": "a", "b": "b"},
             "deps": ["a", "b"],
             "passenv": set(["a", "b"]),
-            "whitelist_externals": ["a", "b"],
+            "allowlist_externals": ["a", "b"],
         }
         def_tec.configure_mock(**deepcopy(full_attrs))
         for prop in propnames:
@@ -233,13 +233,13 @@ class HooksTestCase(TestCase):
             "setenv": {"a": "a", "c": "c"},
             "deps": ["a", "c"],
             "passenv": set(["a", "c"]),
-            "whitelist_externals": ["a", "c"],
+            "allowlist_externals": ["a", "c"],
         }
         result_attrs = {
             "setenv": {"a": "a", "b": "b", "c": "c"},
             "deps": ["a", "b", "c"],
             "passenv": set(["a", "b", "c"]),
-            "whitelist_externals": ["a", "b", "c"],
+            "allowlist_externals": ["a", "b", "c"],
         }
         tec = MagicMock()
         def_tec = MagicMock()
@@ -373,13 +373,13 @@ class HooksTestCase(TestCase):
             "setenv": "a\nb",
             "deps": "a",
             "passenv": "TEST_*",
-            "whitelist_externals": "mycmd\nmyothercmd",
+            "allowlist_externals": "mycmd\nmyothercmd",
         }
         def_conf = {
             "setenv": "c\nd",
             "deps": "b",
             "passenv": "*",
-            "whitelist_externals": "bash",
+            "allowlist_externals": "bash",
         }
         set_prop_values_ini("setenv", def_conf, conf)
         self.assertEqual("c\nd\na\nb", def_conf["setenv"])
@@ -387,9 +387,9 @@ class HooksTestCase(TestCase):
         self.assertEqual("b\na", def_conf["deps"])
         set_prop_values_ini("passenv", def_conf, conf)
         self.assertEqual("*\nTEST_*", def_conf["passenv"])
-        set_prop_values_ini("whitelist_externals", def_conf, conf)
+        set_prop_values_ini("allowlist_externals", def_conf, conf)
         self.assertEqual(
-            "bash\nmycmd\nmyothercmd", def_conf["whitelist_externals"]
+            "bash\nmycmd\nmyothercmd", def_conf["allowlist_externals"]
         )
 
     def test_lsr_path(self):

--- a/tests/unit/test_hooks4.py
+++ b/tests/unit/test_hooks4.py
@@ -47,7 +47,7 @@ DEFAULT_INI = {
             "\nLSR_CONFIGDIR = {lsr_configdir}"
         ),
         "deps": ("\npytest" "\nPyYAML" "\ncolorama"),
-        "whitelist_externals": ("\nbash" "\ntouch" "\nfind"),
+        "allowlist_externals": ("\nbash" "\ntouch" "\nfind"),
         "command": "pytest tests/unit",
     },
     "testenv:py36": {
@@ -76,7 +76,7 @@ TOX_INI_MISSING_TOX_SECTION_MERGED = {
             "\nLSR_CONFIGDIR = ./config"
         ),
         "deps": ("\npytest" "\nPyYAML" "\ncolorama"),
-        "whitelist_externals": ("\nbash" "\ntouch" "\nfind"),
+        "allowlist_externals": ("\nbash" "\ntouch" "\nfind"),
         "command": "pytest tests/unit",
     },
     "testenv:py36": {
@@ -94,7 +94,7 @@ TOX_INI_OVERRIDE_DEFAULTS = {
     "testenv": {
         "setenv": "\nLSR_SCRIPTDIR = {lsr_scriptdir}/../../my_scripts",
         "deps": ("\nblack" "\npylint"),
-        "whitelist_externals": ("\nexpect" "\nsed" "\ngrep"),
+        "allowlist_externals": ("\nexpect" "\nsed" "\ngrep"),
         "command": "pytest tests/unit {posargs}",
     },
     "lsr_black": {
@@ -121,7 +121,7 @@ TOX_INI_OVERRIDE_DEFAULTS_MERGED = {
             "\nLSR_SCRIPTDIR = ./scripts/../../my_scripts"
         ),
         "deps": ("\npytest" "\nPyYAML" "\ncolorama" "\n" "\nblack" "\npylint"),
-        "whitelist_externals": (
+        "allowlist_externals": (
             "\nbash" "\ntouch" "\nfind" "\n" "\nexpect" "\nsed" "\ngrep"
         ),
         "command": "pytest tests/unit {posargs}",

--- a/tox.ini
+++ b/tox.ini
@@ -147,7 +147,7 @@ deps =
 commands = {[coveralls]basepython}
 
 [testenv:shellcheck]
-whitelist_externals =
+allowlist_externals =
     find
 commands =
     find src tests -name *.sh -exec shellcheck \


### PR DESCRIPTION
- Use check-ansible-managed.sh script instead of inline bash
- Use allowlist instead of whitelist - NOTE - this breaks support for tox v2 - this means this release will be tox-lsr 3.0.0
- other cleanup
