### PR TITLE
ci: manually install python 2.7

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -24,7 +24,14 @@ jobs:
     steps:
       - name: checkout PR
         uses: actions/checkout@v3
-      - name: Set up Python
+      - name: Set up Python 2.7
+        if: ${{ matrix.pyver_os.ver == '2.7' }}
+        run: |
+          set -euxo pipefail
+          sudo apt update
+          sudo apt install -y python2.7
+      - name: Set up Python 3
+        if: ${{ matrix.pyver_os.ver != '2.7' }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.pyver_os.ver }}
@@ -49,33 +56,3 @@ jobs:
           # run python unit tests only on the toxenv that matches the
           # current system version of python
           tox -e "${linters:-}$toxpyenv,coveralls"
-  python-26:
-    runs-on: ubuntu-16.04
-    steps:
-      - name: checkout PR
-        uses: actions/checkout@v3
-      - name: Install python, dependencies
-        run: |
-          set -euo pipefail
-          curl -sSf --retry 5 -o python-2.6.tar.bz2 ${PY26URL}
-          sudo tar xjf python-2.6.tar.bz2 --directory /
-          myuid=$(id -u)
-          mygid=$(id -g)
-          sudo chown -R $myuid:$mygid /home/travis/virtualenv
-          source /home/travis/virtualenv/python2.6/bin/activate
-          set -x
-          pip install -rtox-requirements.txt
-        env:
-          # yamllint disable-line rule:line-length
-          PY26URL: https://storage.googleapis.com/travis-ci-language-archives/python/binaries/ubuntu/14.04/x86_64/python-2.6.tar.bz2
-          VIRTUAL_ENV_DISABLE_PROMPT: "true"
-      - name: Run tox tests
-        run: |
-          set -euo pipefail
-          source /home/travis/virtualenv/python2.6/bin/activate
-          set -x
-          tox -e py26-tox20,coveralls26
-        env:
-          SAFETY_CMD: "echo skipping safety"
-          VIRTUAL_ENV_DISABLE_PROMPT: "true"
-          COVERALLS_CMD: "echo skipping report in py26-tox20 - will use separate testenv"

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ deps =
     tox30: tox==3.*
     py27: mock
 commands =
-    {env:SAFETY_CMD:safety} check -i 52495 -i 47833 -i 42559 -i 42218 -i 40291 -i 38765 -i 39611 -i 44492 -i 51457 -i 51499 --full-report  # ignore pip, PyYAML problems
+    {env:SAFETY_CMD:safety} check -i 58755 -i 52495 -i 47833 -i 42559 -i 42218 -i 40291 -i 38765 -i 39611 -i 44492 -i 51457 -i 51499 --full-report  # ignore pip, PyYAML problems
     pytest --cov=tox_lsr --cov-report=term-missing tests
     {env:COVERALLS_CMD:coveralls --output={envname}-coverage.txt}
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 
 [tox]
 envlist =
-    py26-tox20
     py{27,35,36,38,39,310,311}-tox30
     py{38,39,310,311}-tox40
     black, isort, pylint, flake8, mypy, bandit, pydocstyle
@@ -18,18 +17,15 @@ skip_install = True
 description =
     {envname}: Run unit tests for {envname}
 deps =
-    idna<2.8 ; python_version < "2.7"
     safety ; python_version >= "3"
     unittest2
     pytest
     pytest-cov
     coveralls
     py
-    PyYAML<5.1 ; python_version < "2.7"
     tox40: tox==4.*
     tox30: tox==3.*
-    tox20: tox==2.4
-    py{26,27}: mock
+    py27: mock
 commands =
     {env:SAFETY_CMD:safety} check -i 52495 -i 47833 -i 42559 -i 42218 -i 40291 -i 38765 -i 39611 -i 44492 -i 51457 -i 51499 --full-report  # ignore pip, PyYAML problems
     pytest --cov=tox_lsr --cov-report=term-missing tests
@@ -137,13 +133,6 @@ commands = python src/tox_lsr/test_scripts/custom_coveralls.py
 [testenv:coveralls]
 basepython = {[coveralls]basepython}
 deps = coveralls
-commands = {[coveralls]basepython}
-
-[testenv:coveralls26]
-basepython = {[coveralls]basepython}
-deps =
-    coverage==4.5.4
-    coveralls==1.11.1
 commands = {[coveralls]basepython}
 
 [testenv:shellcheck]


### PR DESCRIPTION
python 2.7 no longer supported by setup-python action.
Also skip testing with python 2.6/tox 2.x - no longer
supported by tox-lsr 3.x

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
