### PR TITLE
Make markdownlint consistent with our GH workflows, add convert_readme

### DIFF
--- a/src/tox_lsr/config_files/tox-default.ini
+++ b/src/tox_lsr/config_files/tox-default.ini
@@ -461,13 +461,33 @@ allowlist_externals = podman
     rm
 setenv =
     {[testenv]setenv}
-    GITHUB_OUTPUT = /tmp/mdl.log
-    INPUT_PATH = .
+    INPUT_CONFIG=.markdownlint.yaml
+    INPUT_FIX=true
 commands = bash {lsr_scriptdir}/setup_module_utils.sh
     {[lsr_config]commands_pre}
     {env:LSR_CONTAINER_RUNTIME:podman} run --rm --privileged \
       -v {toxinidir}:/workdir --workdir /workdir \
-      -e GITHUB_OUTPUT -e INPUT_PATH \
-      ghcr.io/actionshub/markdownlint:v3.1.3 \
+      -e INPUT_CONFIG -e INPUT_FIX \
+      docker://avtodev/markdown-lint:master \
+      README.md \
       {env:RUN_MARKDOWNLINT_EXTRA_ARGS:} {posargs}
+    {[lsr_config]commands_post}
+
+[testenv:convert_readme]
+changedir = {toxinidir}
+allowlist_externals = podman
+    bash
+    cat
+    rm
+setenv =
+    {[testenv]setenv}
+commands = bash {lsr_scriptdir}/setup_module_utils.sh
+    {[lsr_config]commands_pre}
+    {env:LSR_CONTAINER_RUNTIME:podman} run --rm --privileged \
+      -v {toxinidir}:/workdir --workdir /workdir \
+      docker://pandoc/core:latest \
+      --from gfm --to html5 --toc --shift-heading-level-by=-1 \
+      --template .pandoc_template.html5 \
+      --output README.html README.md \
+      {env:RUN_CONVERT_README_EXTRA_ARGS:} {posargs}
     {[lsr_config]commands_post}

--- a/tests/fixtures/test_tox_merge_ini/result.ini
+++ b/tests/fixtures/test_tox_merge_ini/result.ini
@@ -367,15 +367,34 @@ allowlist_externals = podman
 	cat
 	rm
 setenv = {[testenv]setenv}
-	GITHUB_OUTPUT = /tmp/mdl.log
-	INPUT_PATH = .
+	INPUT_CONFIG=.markdownlint.yaml
+	INPUT_FIX=true
 commands = bash {lsr_scriptdir}/setup_module_utils.sh
 	{[lsr_config]commands_pre}
 	{env:LSR_CONTAINER_RUNTIME:podman} run --rm --privileged \
 	-v {toxinidir}:/workdir --workdir /workdir \
-	-e GITHUB_OUTPUT -e INPUT_PATH \
-	ghcr.io/actionshub/markdownlint:v3.1.3 \
+	-e INPUT_CONFIG -e INPUT_FIX \
+	docker://avtodev/markdown-lint:master \
+	README.md \
 	{env:RUN_MARKDOWNLINT_EXTRA_ARGS:} {posargs}
+	{[lsr_config]commands_post}
+
+[testenv:convert_readme]
+changedir = {toxinidir}
+allowlist_externals = podman
+	bash
+	cat
+	rm
+setenv = {[testenv]setenv}
+commands = bash {lsr_scriptdir}/setup_module_utils.sh
+	{[lsr_config]commands_pre}
+	{env:LSR_CONTAINER_RUNTIME:podman} run --rm --privileged \
+	-v {toxinidir}:/workdir --workdir /workdir \
+	docker://pandoc/core:latest \
+	--from gfm --to html5 --toc --shift-heading-level-by=-1 \
+	--template .pandoc_template.html5 \
+	--output README.html README.md \
+	{env:RUN_CONVERT_README_EXTRA_ARGS:} {posargs}
 	{[lsr_config]commands_post}
 
 [custom_common]


### PR DESCRIPTION
Add tox environments for markdownlint and test_converting_readme (convert_readme here) that has been added in https://github.com/linux-system-roles/.github/pull/41