### PR TITLE
plugin-scan - use explicit collection requirements

### DIFF
--- a/src/tox_lsr/config_files/tox-default.ini
+++ b/src/tox_lsr/config_files/tox-default.ini
@@ -380,8 +380,17 @@ allowlist_externals =
 deps =
     ansible==6.*
     jinja2==2.7.* ; python_version <= "3.7"
+setenv =
+    ANSIBLE_COLLECTIONS_PATHS = {envdir}
 commands =
     curl -L -o {envdir}/report-modules-plugins.py https://raw.githubusercontent.com/linux-system-roles/auto-maintenance/master/report-modules-plugins.py
+    bash -c '\
+    set -euxo pipefail; \
+    for file in meta/collection-requirements.yml tests/collection-requirements.yml; do \
+      if [ -f "$file" ]; then \
+        ansible-galaxy collection install -vv --force -r "$file"; \
+      fi; \
+    done'
     python {env:LSR_REPORT_MODULES_PLUGINS:{envdir}/report-modules-plugins.py} \
       {env:RUN_PLUGIN_SCAN_EXTRA_ARGS:} --details {posargs} .
 

--- a/tests/fixtures/test_tox_merge_ini/result.ini
+++ b/tests/fixtures/test_tox_merge_ini/result.ini
@@ -306,7 +306,15 @@ allowlist_externals = curl
 	bash
 deps = ansible==6.*
 	jinja2==2.7.* ; python_version <= "3.7"
+setenv = ANSIBLE_COLLECTIONS_PATHS = {envdir}
 commands = curl -L -o {envdir}/report-modules-plugins.py https://raw.githubusercontent.com/linux-system-roles/auto-maintenance/master/report-modules-plugins.py
+	bash -c '\
+	set -euxo pipefail; \
+	for file in meta/collection-requirements.yml tests/collection-requirements.yml; do \
+	if [ -f "$file" ]; then \
+	ansible-galaxy collection install -vv --force -r "$file"; \
+	fi; \
+	done'
 	python {env:LSR_REPORT_MODULES_PLUGINS:{envdir}/report-modules-plugins.py} \
 	{env:RUN_PLUGIN_SCAN_EXTRA_ARGS:} --details {posargs} .
 


### PR DESCRIPTION
Install the collections from meta/collection-requirements.yml
and tests/collection-requirements.yml to override those found
in the `ansible` bundle.  We have to use an old ansible to
maintain compatability with jinja 2.7 and the collections
bundled there are not updated with newer versions of
ansible.posix, community.general, etc.

At some point when we drop compatability with EL7 and python2,
we can drop support for jinja 2.7 and use the latest ansible.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
