### PR TITLE
ostree - ansible uses platform-python

### DIFF
--- a/src/tox_lsr/osbuild-manifests/images/lsr.mpp.yml
+++ b/src/tox_lsr/osbuild-manifests/images/lsr.mpp.yml
@@ -14,7 +14,6 @@ mpp-vars:
   lsr_packages:  # base packages required for lsr and ansible
   - sudo # non-root access
   - openssh-server  # ssh access
-  - python3  # Ansible basic requirement
   - python3-rpm  # Ansible package module
   - pam  # ssh server dep
   - crypto-policies  # ssh server dep


### PR DESCRIPTION
We do not need to install python3 by default for Ansible because it
will use the platform-python by default.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
