### PR TITLE
ostree - do not remove man pages

### DIFF
--- a/src/tox_lsr/osbuild-manifests/images/lsr.mpp.yml
+++ b/src/tox_lsr/osbuild-manifests/images/lsr.mpp.yml
@@ -37,7 +37,7 @@ pipelines:
       - mpp-eval: distro_gpg_keys
       disable_dracut: true
       exclude:
-        docs: true
+        docs: false  # ssh requires man pages for testing
     inputs:
       packages:
         type: org.osbuild.files


### PR DESCRIPTION
man pages are required for testing ssh

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
