### PR TITLE
add support for ansible-core 2.16

### DIFF
--- a/src/tox_lsr/config_files/tox-default.ini
+++ b/src/tox_lsr/config_files/tox-default.ini
@@ -371,6 +371,17 @@ deps =
 commands =
     {[qemu_common]commands}
 
+[testenv:qemu-ansible-core-2.16]
+changedir = {[qemu_common]changedir}
+basepython = {[qemu_common]basepython}
+setenv =
+    {[qemu_common]setenv}
+deps =
+    {[qemu_common]deps}
+    ansible-core==2.16.*
+commands =
+    {[qemu_common]commands}
+
 [testenv:ansible-plugin-scan]
 changedir = {env:LSR_RUN_TEST_DIR:{toxinidir}}
 basepython = python3
@@ -380,7 +391,7 @@ allowlist_externals =
 deps =
     ansible==6.*
     jinja2==2.7.* ; python_version <= "3.7"
-setenv =
+setenv =  # change this to ANSIBLE_COLLECTIONS_PATH if using a later ansible version
     ANSIBLE_COLLECTIONS_PATHS = {envdir}
 commands =
     curl -L -o {envdir}/report-modules-plugins.py https://raw.githubusercontent.com/linux-system-roles/auto-maintenance/master/report-modules-plugins.py
@@ -459,6 +470,16 @@ setenv =
     {[container_common]setenv}
 deps =
     ansible-core==2.15.*
+commands =
+    {[container_common]commands}
+
+[testenv:container-ansible-core-2.16]
+changedir = {[container_common]changedir}
+basepython = {[container_common]basepython}
+setenv =
+    {[container_common]setenv}
+deps =
+    ansible-core==2.16.*
 commands =
     {[container_common]commands}
 

--- a/src/tox_lsr/test_scripts/runcontainer.sh
+++ b/src/tox_lsr/test_scripts/runcontainer.sh
@@ -14,8 +14,17 @@ CONTAINER_SKIP_TAGS=${CONTAINER_SKIP_TAGS:---skip-tags tests::uses_selinux}
 CONTAINER_CONFIG="$HOME/.config/linux-system-roles.json"
 
 COLLECTION_BASE_PATH="${COLLECTION_BASE_PATH:-$TOX_WORK_DIR}"
-export ANSIBLE_COLLECTIONS_PATHS="${ANSIBLE_COLLECTIONS_PATHS:-$COLLECTION_BASE_PATH}"
 LOCAL_COLLECTION="${LOCAL_COLLECTION:-fedora/linux_system_roles}"
+
+is_ansible_env_var_supported() {
+    ansible-config list | grep -q "name: ${1}$"
+}
+
+if is_ansible_env_var_supported ANSIBLE_COLLECTIONS_PATH; then
+    export ANSIBLE_COLLECTIONS_PATH="${ANSIBLE_COLLECTIONS_PATH:-$COLLECTION_BASE_PATH}"
+else
+    export ANSIBLE_COLLECTIONS_PATHS="${ANSIBLE_COLLECTIONS_PATHS:-$COLLECTION_BASE_PATH}"
+fi
 
 logit() {
     local level

--- a/src/tox_lsr/test_scripts/runqemu.py
+++ b/src/tox_lsr/test_scripts/runqemu.py
@@ -92,10 +92,12 @@ def is_ansible_env_var_supported(env_var_name):
         return True
     return False
 
+
 if is_ansible_env_var_supported("ANSIBLE_COLLECTIONS_PATH"):
     COLL_PATH_ENV_VAR = "ANSIBLE_COLLECTIONS_PATH"
 else:
     COLL_PATH_ENV_VAR = "ANSIBLE_COLLECTIONS_PATHS"
+
 
 def get_metadata_from_file(path, attr_key):
     """Get metadata from key attr_key in file at given path."""
@@ -1126,9 +1128,7 @@ def setup_callback_plugins(pretty, profile, profile_task_limit, test_env):
     )
     if not os.path.isdir(callback_plugin_dir):
         os.makedirs(callback_plugin_dir)
-    galaxy_env = {
-        COLL_PATH_ENV_VAR: os.environ["LSR_TOX_ENV_TMP_DIR"]
-    }
+    galaxy_env = {COLL_PATH_ENV_VAR: os.environ["LSR_TOX_ENV_TMP_DIR"]}
     debug_py = os.path.join(callback_plugin_dir, "debug.py")
     profile_py = os.path.join(callback_plugin_dir, "profile_tasks.py")
     if (pretty and not os.path.isfile(debug_py)) or (

--- a/src/tox_lsr/test_scripts/runqemu.py
+++ b/src/tox_lsr/test_scripts/runqemu.py
@@ -92,6 +92,10 @@ def is_ansible_env_var_supported(env_var_name):
         return True
     return False
 
+if is_ansible_env_var_supported("ANSIBLE_COLLECTIONS_PATH"):
+    COLL_PATH_ENV_VAR = "ANSIBLE_COLLECTIONS_PATH"
+else:
+    COLL_PATH_ENV_VAR = "ANSIBLE_COLLECTIONS_PATHS"
 
 def get_metadata_from_file(path, attr_key):
     """Get metadata from key attr_key in file at given path."""
@@ -925,7 +929,7 @@ def run_ansible_playbooks(  # noqa: C901
     if image_alias:
         test_env["TEST_HOSTALIASES"] = image_alias
     if collection_path:
-        test_env["ANSIBLE_COLLECTIONS_PATHS"] = collection_path
+        test_env[COLL_PATH_ENV_VAR] = collection_path
     if write_inventory:
         test_env["TEST_INVENTORY"] = write_inventory
     for batch in batches:
@@ -1073,7 +1077,7 @@ def install_requirements(sourcedir, collection_path, test_env, collection):
             force_flag = "--force"
     coll_rqf = os.path.join(sourcedir, "meta", "collection-requirements.yml")
     tests_rqf = os.path.join(sourcedir, "tests", "collection-requirements.yml")
-    galaxy_env = {"ANSIBLE_COLLECTIONS_PATHS": collection_path}
+    galaxy_env = {COLL_PATH_ENV_VAR: collection_path}
     for reqfile in [coll_rqf, tests_rqf]:
         if os.path.isfile(reqfile):
             ag_cmd = [
@@ -1094,7 +1098,7 @@ def install_requirements(sourcedir, collection_path, test_env, collection):
                 stderr=sys.stderr,
                 env=galaxy_env,
             )
-            test_env["ANSIBLE_COLLECTIONS_PATHS"] = collection_path
+            test_env[COLL_PATH_ENV_VAR] = collection_path
     if collection_save_file:
         subprocess.check_call(  # nosec
             [
@@ -1123,7 +1127,7 @@ def setup_callback_plugins(pretty, profile, profile_task_limit, test_env):
     if not os.path.isdir(callback_plugin_dir):
         os.makedirs(callback_plugin_dir)
     galaxy_env = {
-        "ANSIBLE_COLLECTIONS_PATHS": os.environ["LSR_TOX_ENV_TMP_DIR"]
+        COLL_PATH_ENV_VAR: os.environ["LSR_TOX_ENV_TMP_DIR"]
     }
     debug_py = os.path.join(callback_plugin_dir, "debug.py")
     profile_py = os.path.join(callback_plugin_dir, "profile_tasks.py")

--- a/tests/fixtures/test_tox_merge_ini/result.ini
+++ b/tests/fixtures/test_tox_merge_ini/result.ini
@@ -299,6 +299,14 @@ deps = {[qemu_common]deps}
 	ansible-core==2.15.*
 commands = {[qemu_common]commands}
 
+[testenv:qemu-ansible-core-2.16]
+changedir = {[qemu_common]changedir}
+basepython = {[qemu_common]basepython}
+setenv = {[qemu_common]setenv}
+deps = {[qemu_common]deps}
+	ansible-core==2.16.*
+commands = {[qemu_common]commands}
+
 [testenv:ansible-plugin-scan]
 changedir = {env:LSR_RUN_TEST_DIR:{toxinidir}}
 basepython = python3
@@ -306,7 +314,8 @@ allowlist_externals = curl
 	bash
 deps = ansible==6.*
 	jinja2==2.7.* ; python_version <= "3.7"
-setenv = ANSIBLE_COLLECTIONS_PATHS = {envdir}
+setenv = # change this to ANSIBLE_COLLECTIONS_PATH if using a later ansible version
+	ANSIBLE_COLLECTIONS_PATHS = {envdir}
 commands = curl -L -o {envdir}/report-modules-plugins.py https://raw.githubusercontent.com/linux-system-roles/auto-maintenance/master/report-modules-plugins.py
 	bash -c '\
 	set -euxo pipefail; \
@@ -368,6 +377,13 @@ setenv = {[container_common]setenv}
 deps = ansible-core==2.15.*
 commands = {[container_common]commands}
 
+[testenv:container-ansible-core-2.16]
+changedir = {[container_common]changedir}
+basepython = {[container_common]basepython}
+setenv = {[container_common]setenv}
+deps = ansible-core==2.16.*
+commands = {[container_common]commands}
+
 [testenv:markdownlint]
 changedir = {toxinidir}
 allowlist_externals = podman
@@ -407,6 +423,16 @@ commands = bash {lsr_scriptdir}/setup_module_utils.sh
 	{env:RUN_CONVERT_README_EXTRA_ARGS:} {posargs}
 	{[lsr_config]commands_post}
 
+[testenv:build_ostree_image]
+changedir = {toxinidir}
+allowlist_externals = bash
+	cat
+	rm
+	make
+	sudo
+setenv = {[testenv]setenv}
+commands = bash {lsr_scriptdir}/build_ostree_image.sh {posargs}
+
 [custom_common]
 setenv = CUSTOMCOMMON = customcommon
 commands = customcommoncmd
@@ -425,12 +451,3 @@ commands = override_custom_cmd
 deps = override_custom_deps1
 	override_custom_deps2
 
-[testenv:build_ostree_image]
-changedir = {toxinidir}
-allowlist_externals = bash
-    cat
-    rm
-    make
-    sudo
-setenv = {[testenv]setenv}
-commands = bash {lsr_scriptdir}/build_ostree_image.sh {posargs}


### PR DESCRIPTION
add support for ansible-core 2.16
Use `ANSIBLE_COLLECTIONS_PATH` if possible, otherwise, fallback
on the older `ANSIBLE_COLLECTIONS_PATHS` which is now deprecated.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
