### PR TITLE
woke.yml: ignore autogenerated CHANGELOG.md

### DIFF
--- a/src/tox_lsr/config_files/woke.yml
+++ b/src/tox_lsr/config_files/woke.yml
@@ -3,6 +3,7 @@ ignore_files:
   - .github
   - .README.html
   - .sanity-ansible-ignore-*.txt
+  - CHANGELOG.md
   - pylintrc
   - vendor
   - tests/sanity


### PR DESCRIPTION
Causes issues in ha_cluster role due to '.sanity' in the changelog:
https://github.com/linux-system-roles/ha_cluster/actions/runs/7146096868