### PR TITLE
Use ansible-lint from pip - the container is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ environment variables:
 * `RUN_YAMLLINT_EXTRA_ARGS` - extra command line arguments to provide to
   yamllint
 * `RUN_ANSIBLE_LINT_EXTRA_ARGS` - extra command line arguments to provide to
-  ansible-lint
+  ansible-lint and ansible-lint-collection
 * `LSR_ROLE2COLL_VERSION` - a tag/commit of the lsr_role2collection script to
   use for the collection tox test.  The default is the latest stable version.
 * `LSR_ROLE2COLL_NAMESPACE` - namespace to use for the lsr_role2collection
@@ -382,6 +382,11 @@ workflow like this:
 This will convert your role to a collection, run `ansible-test` with only the
 `ansible-doc` test, and dump what the converted doc looks like, or dump errors
 if your doc could not be rendered correctly.
+
+To run `ansible-lint-collection` you must first convert to collection.
+```
+> tox -e collection,ansible-lint-collection
+```
 
 ### QEMU testing
 

--- a/src/tox_lsr/config_files/tox-default.ini
+++ b/src/tox_lsr/config_files/tox-default.ini
@@ -30,7 +30,6 @@ setenv =
     LSR_ROLE2COLL_NAMESPACE = fedora
     LSR_ROLE2COLL_NAME = linux_system_roles
     LSR_TOX_ENV_TMP_DIR = {envtmpdir}
-    LSR_ANSIBLE_LINT_CONTAINER = {env:LSR_ANSIBLE_LINT_CONTAINER:quay.io/ansible/creator-ee:v0.19.0}
 deps =
     py{26,27,36,37,38,39,310,311}: pytest-cov
     py{27,36,37,38,39,310,311}: pytest>=3.5.1
@@ -236,18 +235,15 @@ commands =
 [testenv:ansible-lint]
 changedir = {toxinidir}
 allowlist_externals =
-    podman
     bash
+deps =
+    ansible-lint
 commands_pre =
     bash {lsr_scriptdir}/ansible-lint-helper.sh pre
 commands =
     bash {lsr_scriptdir}/setup_module_utils.sh
     {[lsr_config]commands_pre}
-    {env:LSR_CONTAINER_RUNTIME:podman} run --rm --privileged \
-      -v {toxinidir}:/workdir --workdir /workdir \
-      --entrypoint /usr/local/bin/ansible-lint \
-      {env:LSR_ANSIBLE_LINT_CONTAINER} \
-      {env:RUN_ANSIBLE_LINT_EXTRA_ARGS:} {posargs}
+    ansible-lint {env:RUN_ANSIBLE_LINT_EXTRA_ARGS:} {posargs}
     {[lsr_config]commands_post}
 commands_post =
     bash {lsr_scriptdir}/ansible-lint-helper.sh post
@@ -255,19 +251,15 @@ commands_post =
 [testenv:ansible-lint-collection]
 changedir = {toxworkdir}/ansible_collections/{env:LSR_ROLE2COLL_NAMESPACE}/{env:LSR_ROLE2COLL_NAME}
 allowlist_externals =
-    podman
     bash
     cp
+deps =
+    ansible-lint
 commands =
     bash {lsr_scriptdir}/setup_module_utils.sh
     {[lsr_config]commands_pre}
     cp {toxinidir}/.ansible-lint {toxworkdir}/ansible_collections/{env:LSR_ROLE2COLL_NAMESPACE}/{env:LSR_ROLE2COLL_NAME}
-    {env:LSR_CONTAINER_RUNTIME:podman} run --rm --privileged \
-      -v {toxworkdir}/ansible_collections/{env:LSR_ROLE2COLL_NAMESPACE}/{env:LSR_ROLE2COLL_NAME}:/workdir \
-      --workdir /workdir \
-      --entrypoint /usr/local/bin/ansible-lint \
-      {env:LSR_ANSIBLE_LINT_CONTAINER} \
-      {env:RUN_ANSIBLE_LINT_EXTRA_ARGS:} {posargs}
+    ansible-lint {env:RUN_ANSIBLE_LINT_EXTRA_ARGS:} {posargs}
     {[lsr_config]commands_post}
 
 [testenv:ansible-test]

--- a/tests/fixtures/test_tox_merge_ini/result.ini
+++ b/tests/fixtures/test_tox_merge_ini/result.ini
@@ -26,7 +26,6 @@ setenv = PYTHONPATH = {env:LSR_PYTHONPATH:}{toxinidir}/library:{toxinidir}/modul
 	LSR_ROLE2COLL_NAMESPACE = fedora
 	LSR_ROLE2COLL_NAME = linux_system_roles
 	LSR_TOX_ENV_TMP_DIR = {envtmpdir}
-	LSR_ANSIBLE_LINT_CONTAINER = {env:LSR_ANSIBLE_LINT_CONTAINER:quay.io/ansible/creator-ee:v0.19.0}
 	LOCAL1 = local1
 	LOCAL2 = local2
 deps = py{26,27,36,37,38,39,310,311}: pytest-cov
@@ -197,33 +196,24 @@ commands = bash {lsr_scriptdir}/setup_module_utils.sh
 
 [testenv:ansible-lint]
 changedir = {toxinidir}
-allowlist_externals = podman
-	bash
+allowlist_externals = bash
+deps = ansible-lint
 commands_pre = bash {lsr_scriptdir}/ansible-lint-helper.sh pre
 commands = bash {lsr_scriptdir}/setup_module_utils.sh
 	{[lsr_config]commands_pre}
-	{env:LSR_CONTAINER_RUNTIME:podman} run --rm --privileged \
-	-v {toxinidir}:/workdir --workdir /workdir \
-	--entrypoint /usr/local/bin/ansible-lint \
-	{env:LSR_ANSIBLE_LINT_CONTAINER} \
-	{env:RUN_ANSIBLE_LINT_EXTRA_ARGS:} {posargs}
+	ansible-lint {env:RUN_ANSIBLE_LINT_EXTRA_ARGS:} {posargs}
 	{[lsr_config]commands_post}
 commands_post = bash {lsr_scriptdir}/ansible-lint-helper.sh post
 
 [testenv:ansible-lint-collection]
 changedir = {toxworkdir}/ansible_collections/{env:LSR_ROLE2COLL_NAMESPACE}/{env:LSR_ROLE2COLL_NAME}
-allowlist_externals = podman
-	bash
+allowlist_externals = bash
 	cp
+deps = ansible-lint
 commands = bash {lsr_scriptdir}/setup_module_utils.sh
 	{[lsr_config]commands_pre}
 	cp {toxinidir}/.ansible-lint {toxworkdir}/ansible_collections/{env:LSR_ROLE2COLL_NAMESPACE}/{env:LSR_ROLE2COLL_NAME}
-	{env:LSR_CONTAINER_RUNTIME:podman} run --rm --privileged \
-	-v {toxworkdir}/ansible_collections/{env:LSR_ROLE2COLL_NAMESPACE}/{env:LSR_ROLE2COLL_NAME}:/workdir \
-	--workdir /workdir \
-	--entrypoint /usr/local/bin/ansible-lint \
-	{env:LSR_ANSIBLE_LINT_CONTAINER} \
-	{env:RUN_ANSIBLE_LINT_EXTRA_ARGS:} {posargs}
+	ansible-lint {env:RUN_ANSIBLE_LINT_EXTRA_ARGS:} {posargs}
 	{[lsr_config]commands_post}
 
 [testenv:ansible-test]


### PR DESCRIPTION
The ansible-lint container is deprecated, so use ansible-lint from
pypi instead.
