### PR TITLE
use ansible-test 2.16; collections will also copy ignore files

### DIFF
--- a/src/tox_lsr/config_files/tox-default.ini
+++ b/src/tox_lsr/config_files/tox-default.ini
@@ -30,6 +30,7 @@ setenv =
     LSR_ROLE2COLL_NAMESPACE = fedora
     LSR_ROLE2COLL_NAME = linux_system_roles
     LSR_TOX_ENV_TMP_DIR = {envtmpdir}
+    LSR_SRC_OWNER = {env:LSR_SRC_OWNER:linux-system-roles}
 deps =
     py{26,27,36,37,38,39,310,311}: pytest-cov
     py{27,36,37,38,39,310,311}: pytest>=3.5.1
@@ -258,7 +259,6 @@ deps =
 commands =
     bash {lsr_scriptdir}/setup_module_utils.sh
     {[lsr_config]commands_pre}
-    cp {toxinidir}/.ansible-lint {toxworkdir}/ansible_collections/{env:LSR_ROLE2COLL_NAMESPACE}/{env:LSR_ROLE2COLL_NAME}
     ansible-lint {env:RUN_ANSIBLE_LINT_EXTRA_ARGS:} {posargs}
     {[lsr_config]commands_post}
 
@@ -268,7 +268,7 @@ commands =
 # ansible 2.10 seems better in this respect
 basepython = python3
 deps =
-    {env:LSR_ANSIBLE_TEST_DEP:ansible-core==2.14.*}
+    {env:LSR_ANSIBLE_TEST_DEP:ansible-core==2.16.*}
 commands =
     bash {lsr_scriptdir}/runansible-test.sh
 
@@ -293,6 +293,7 @@ deps =
     PyYAML  # needed for runqemu
     ruamel.yaml  # needed for collection support
     beautifulsoup4  # needed for centoshtml support
+    selinux  # needed for delegate_to: localhost for file, copy, etc.
 commands =
     python {lsr_scriptdir}/runqemu.py {posargs}
 
@@ -386,7 +387,7 @@ deps =
 setenv =  # change this to ANSIBLE_COLLECTIONS_PATH if using a later ansible version
     ANSIBLE_COLLECTIONS_PATHS = {envdir}
 commands =
-    curl -L -o {envdir}/report-modules-plugins.py https://raw.githubusercontent.com/linux-system-roles/auto-maintenance/main/report-modules-plugins.py
+    curl -L -o {envdir}/report-modules-plugins.py https://raw.githubusercontent.com/{env:LSR_SRC_OWNER:linux-system-roles}/auto-maintenance/main/report-modules-plugins.py
     bash -c '\
     set -euxo pipefail; \
     for file in meta/collection-requirements.yml tests/collection-requirements.yml; do \

--- a/src/tox_lsr/test_scripts/runansible-test.sh
+++ b/src/tox_lsr/test_scripts/runansible-test.sh
@@ -32,6 +32,7 @@ if [ "${LSR_ANSIBLE_TEST_DEBUG:-false}" = true ]; then
   ansible_test_filter() {
     cat
   }
+  set -x
 else
   default_v_arg=""
   ansible_test_filter() {
@@ -53,16 +54,6 @@ trap "rm -rf $dest_coll_dir" 0
 cp -a "$src_ac_dir" "$dest_coll_dir"
 
 cd "$dest_coll_dir/ansible_collections/$LSR_ROLE2COLL_NAMESPACE/$LSR_ROLE2COLL_NAME"
-
-if [ ! -d tests/sanity ]; then
-  mkdir -p tests/sanity
-fi
-# grab our ignore files
-for file in "$TOXINIDIR"/.sanity-ansible-ignore-*.txt; do
-  if [ -f "$file" ]; then
-    cp "$file" "tests/sanity/${file//*.sanity-ansible-}"
-  fi
-done
 
 if [ "${LSR_ANSIBLE_TEST_DOCKER:-false}" = true ]; then
   ansible-test sanity --docker 2>&1 | ansible_test_filter

--- a/src/tox_lsr/test_scripts/runcollection.sh
+++ b/src/tox_lsr/test_scripts/runcollection.sh
@@ -10,6 +10,10 @@ SCRIPTDIR=$(readlink -f "$(dirname "$0")")
 
 . "${SCRIPTDIR}/utils.sh"
 
+if [ "${LSR_ROLE2COLL_DEBUG:-false}" = true ]; then
+  set -x
+  export LSR_DEBUG=true
+fi
 # Collection commands that are run when `tox -e collection`:
 role=$(basename "${TOPDIR}")
 STABLE_TAG=${1:-main}
@@ -19,7 +23,7 @@ testlist="yamllint,flake8,shellcheck,ansible-plugin-scan"
 #testlist="${testlist},py38"
 
 if [ -z "${LSR_ROLE2COLL_PATH:-}" ]; then
-  automaintenancerepo=https://raw.githubusercontent.com/linux-system-roles/auto-maintenance/
+  automaintenancerepo=https://raw.githubusercontent.com/${LSR_SRC_OWNER}/auto-maintenance/
   curl -s -L -o "$LSR_TOX_ENV_DIR/tmp/lsr_role2collection.py" "${automaintenancerepo}${STABLE_TAG}"/lsr_role2collection.py
   curl -s -L -o "$LSR_TOX_ENV_DIR/tmp/runtime.yml" "${automaintenancerepo}${STABLE_TAG}"/lsr_role2collection/runtime.yml
   # ansible-test needs meta data
@@ -34,25 +38,38 @@ rm -rf "$TOX_WORK_DIR/ansible_collections"
 python "$LSR_TOX_ENV_DIR/tmp/lsr_role2collection.py" --src-path "$TOPDIR/.." --dest-path "$TOX_WORK_DIR" \
   --role "$role" --namespace "${LSR_ROLE2COLL_NAMESPACE}" --collection "${LSR_ROLE2COLL_NAME}" \
   --meta-runtime "$LSR_TOX_ENV_DIR/tmp/runtime.yml" --subrole-prefix "private_${role}_subrole_" \
-  2>&1 | tee "$TOX_ENV_DIR/collection.out"
+  --src-owner "$LSR_SRC_OWNER" 2>&1 | tee "$TOX_ENV_DIR/collection.out"
 
-cp "$LSR_TOX_ENV_DIR/tmp/galaxy.yml" "$TOX_WORK_DIR/ansible_collections/$LSR_ROLE2COLL_NAMESPACE/$LSR_ROLE2COLL_NAME"
+coll_path="$TOX_WORK_DIR/ansible_collections/$LSR_ROLE2COLL_NAMESPACE/$LSR_ROLE2COLL_NAME"
+cp "$LSR_TOX_ENV_DIR/tmp/galaxy.yml" "$coll_path"
 
 # create the collection in this dir to share with other testenvs
-cd "$TOX_WORK_DIR/ansible_collections/$LSR_ROLE2COLL_NAMESPACE/$LSR_ROLE2COLL_NAME"
+cd "$coll_path"
 
 # these are for ansible-lint
-cp "$LSR_CONFIGDIR/collection_yamllint.yml" \
-  "$TOX_WORK_DIR/ansible_collections/$LSR_ROLE2COLL_NAMESPACE/$LSR_ROLE2COLL_NAME/.yamllint.yml"
-touch "$TOX_WORK_DIR/ansible_collections/$LSR_ROLE2COLL_NAMESPACE/$LSR_ROLE2COLL_NAME/CHANGELOG.md"
+cp "$LSR_CONFIGDIR/collection_yamllint.yml" "$coll_path/.yamllint.yml"
+touch "$coll_path/CHANGELOG.md"
+if [ -f "$TOXINIDIR"/.ansible-lint ]; then
+  cp "$TOXINIDIR"/.ansible-lint "$coll_path"
+fi
+
+# grab our ignore files
+for file in "$TOXINIDIR"/.sanity-ansible-ignore-*.txt; do
+  if [ -f "$file" ]; then
+    if [ ! -d tests/sanity ]; then
+      mkdir -p tests/sanity
+    fi
+    cp "$file" "tests/sanity/${file//*.sanity-ansible-}"
+  fi
+done
 
 # unit testing not working yet - will need these and more
 #export RUN_PYTEST_UNIT_DIR="$role/unit"
 #export PYTHONPATH="$MY_LSR_TOX_ENV_DIR/ansible_collections/"${LSR_ROLE2COLL_NAME}"/"${LSR_ROLE2COLL_NAME}"/plugins/modules:$MY_LSR_TOX_ENV_DIR/ansible_collections/"${LSR_ROLE2COLL_NAME}"/"${LSR_ROLE2COLL_NAME}"/plugins/module_utils"
 RUN_YAMLLINT_CONFIG_FILE="$LSR_CONFIGDIR/collection_yamllint.yml" \
 RUN_PLUGIN_SCAN_EXTRA_ARGS="--check-fqcn=plugins" \
-LSR_RUN_TEST_DIR="$TOX_WORK_DIR/ansible_collections/$LSR_ROLE2COLL_NAMESPACE/$LSR_ROLE2COLL_NAME" \
-TOXENV="" tox --workdir "$TOXINIDIR/.tox" -e "$testlist" 2>&1 | tee "$TOX_ENV_DIR/collection.tox.out" || :
+LSR_RUN_TEST_DIR="$coll_path" TOXENV="" tox --workdir "$TOXINIDIR/.tox" -e "$testlist" 2>&1 | \
+  tee "$TOX_ENV_DIR/collection.tox.out" || :
 
 if grep "^ERROR: .*failed" "$TOX_ENV_DIR/collection.tox.out"; then
   lsr_error "${ME}: Some tests failed when run against the converted collection.

--- a/tests/fixtures/test_tox_merge_ini/result.ini
+++ b/tests/fixtures/test_tox_merge_ini/result.ini
@@ -26,6 +26,7 @@ setenv = PYTHONPATH = {env:LSR_PYTHONPATH:}{toxinidir}/library:{toxinidir}/modul
 	LSR_ROLE2COLL_NAMESPACE = fedora
 	LSR_ROLE2COLL_NAME = linux_system_roles
 	LSR_TOX_ENV_TMP_DIR = {envtmpdir}
+	LSR_SRC_OWNER = {env:LSR_SRC_OWNER:linux-system-roles}
 	LOCAL1 = local1
 	LOCAL2 = local2
 deps = py{26,27,36,37,38,39,310,311}: pytest-cov
@@ -212,13 +213,12 @@ allowlist_externals = bash
 deps = ansible-lint
 commands = bash {lsr_scriptdir}/setup_module_utils.sh
 	{[lsr_config]commands_pre}
-	cp {toxinidir}/.ansible-lint {toxworkdir}/ansible_collections/{env:LSR_ROLE2COLL_NAMESPACE}/{env:LSR_ROLE2COLL_NAME}
 	ansible-lint {env:RUN_ANSIBLE_LINT_EXTRA_ARGS:} {posargs}
 	{[lsr_config]commands_post}
 
 [testenv:ansible-test]
 basepython = python3
-deps = {env:LSR_ANSIBLE_TEST_DEP:ansible-core==2.14.*}
+deps = {env:LSR_ANSIBLE_TEST_DEP:ansible-core==2.16.*}
 commands = bash {lsr_scriptdir}/runansible-test.sh
 
 [testenv:woke]
@@ -238,6 +238,7 @@ deps = fmf  # needed for standard-inventory-qcow2
 	PyYAML  # needed for runqemu
 	ruamel.yaml  # needed for collection support
 	beautifulsoup4  # needed for centoshtml support
+	selinux  # needed for delegate_to: localhost for file, copy, etc.
 commands = python {lsr_scriptdir}/runqemu.py {posargs}
 
 [testenv:qemu-ansible-2.9]
@@ -306,7 +307,7 @@ deps = ansible==6.*
 	jinja2==2.7.* ; python_version <= "3.7"
 setenv = # change this to ANSIBLE_COLLECTIONS_PATH if using a later ansible version
 	ANSIBLE_COLLECTIONS_PATHS = {envdir}
-commands = curl -L -o {envdir}/report-modules-plugins.py https://raw.githubusercontent.com/linux-system-roles/auto-maintenance/main/report-modules-plugins.py
+commands = curl -L -o {envdir}/report-modules-plugins.py https://raw.githubusercontent.com/{env:LSR_SRC_OWNER:linux-system-roles}/auto-maintenance/main/report-modules-plugins.py
 	bash -c '\
 	set -euxo pipefail; \
 	for file in meta/collection-requirements.yml tests/collection-requirements.yml; do \


### PR DESCRIPTION
allow collection debugging
add SRC_OWNER and --src-owner for role2collection
use ansible-test 2.16; collections will also copy ignore files
So we don't have to copy the ignore files in both ansible-test
and ansible-lint-collection