### PR TITLE
install ansible-core in qemu-ansible-2.9 venv

### DIFF
--- a/src/tox_lsr/config_files/tox-default.ini
+++ b/src/tox_lsr/config_files/tox-default.ini
@@ -305,6 +305,7 @@ setenv =
     LSR_QEMU_ANSIBLE_CONTAINER = {env:LSR_QEMU_ANSIBLE_CONTAINER:quay.io/linux-system-roles/lsr_ansible_el7:latest}
 deps =
     {[qemu_common]deps}
+    ansible-core  # needed for ansible-config - not actually used to run ansible
 commands =
     {[qemu_common]commands}
 

--- a/tests/fixtures/test_tox_merge_ini/result.ini
+++ b/tests/fixtures/test_tox_merge_ini/result.ini
@@ -247,6 +247,7 @@ basepython = {[qemu_common]basepython}
 setenv = {[qemu_common]setenv}
 	LSR_QEMU_ANSIBLE_CONTAINER = {env:LSR_QEMU_ANSIBLE_CONTAINER:quay.io/linux-system-roles/lsr_ansible_el7:latest}
 deps = {[qemu_common]deps}
+	ansible-core  # needed for ansible-config - not actually used to run ansible
 commands = {[qemu_common]commands}
 
 [testenv:qemu-ansible-core-2.11]


### PR DESCRIPTION
ansible-config is needed for runqemu.py.  install ansible-core to
get this executable.  It is not used to run ansible.
