### PR TITLE
copy pytest config file to tests/unit directory

### DIFF
--- a/src/tox_lsr/config_files/tox-default.ini
+++ b/src/tox_lsr/config_files/tox-default.ini
@@ -47,11 +47,17 @@ commands =
     bash {lsr_scriptdir}/setup_module_utils.sh
     {[lsr_config]commands_pre}
     bash -c 'if [ -d {env:RUN_PYTEST_UNIT_DIR:unit} ]; then \
-        python -m pytest -c {[lsr_pytest]configfile} --durations=5 \
+        testconfigfile="{env:RUN_PYTEST_UNIT_DIR:unit}/$(basename {[lsr_pytest]configfile})"; \
+        cp {[lsr_pytest]configfile} "$testconfigfile"; \
+        rc=0; \
+        python -m pytest -vv -c "$testconfigfile" --durations=5 \
         --cov={toxinidir}/library --cov={toxinidir}/module_utils \
         --cov-report=html:htmlcov-{envname} \
         --cov-report=xml:coverage-{envname}.xml \
-        --cov-report=term {env:RUN_PYTEST_EXTRA_ARGS:} {posargs} {env:RUN_PYTEST_UNIT_DIR:unit} ; \
+        --cov-report=term \
+        {env:RUN_PYTEST_EXTRA_ARGS:} {posargs} {env:RUN_PYTEST_UNIT_DIR:unit} || rc="$?"; \
+        rm -f "$testconfigfile"; \
+        exit "$rc"; \
         fi'
     {[lsr_config]commands_post}
 


### PR DESCRIPTION
The way pytest discovers/collects tests is that if you specify `-c file`
on the command line, it uses the directory of `file` as the root
directory and starts looking for files from there, and it does not
use any other directory, not `--rootdir`, and not any directories
specified on the command line.
https://docs.pytest.org/en/latest/reference/customize.html#initialization-determining-rootdir-and-configfile

Which means pytest looks for test files in places where we do not
want it to look - we only want it to look in the `tests/unit` directory.

This causes problems with github actions because it will look in
directories where it does not have permission to look, and will fail.

The fix is to copy the pytest config file into the `tests/unit` directory
and use `pytest -c tests/unit/$configfile ...`.
