### PR TITLE
add support for image compose subvariants

### DIFF
--- a/src/tox_lsr/test_scripts/runqemu.py
+++ b/src/tox_lsr/test_scripts/runqemu.py
@@ -323,7 +323,10 @@ def get_url(image):
         return source
     elif compose_url:
         variant = image.get("variant")
-        image_urls = composeurl2images(compose_url, "x86_64", variant)
+        subvariant = image.get("subvariant")
+        image_urls = composeurl2images(
+            compose_url, "x86_64", variant, subvariant
+        )
         if len(image_urls) == 1:
             return image_urls[0]
         else:

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ description =
 deps =
     safety ; python_version >= "3"
     unittest2
-    pytest
+    pytest < 8
     pytest-cov
     coveralls
     py


### PR DESCRIPTION
Fedora 40 composes require the use of subvariants
https://kojipkgs.fedoraproject.org/compose/cloud/latest-Fedora-Cloud-40/compose/Cloud/x86_64/images/
to distinguish between Generic and UEFI-UKI
