### PR TITLE
use virtualenv less than version 20.22.0 to allow py27 unit tests to work

### DIFF
--- a/src/tox_lsr/config_files/tox-default.ini
+++ b/src/tox_lsr/config_files/tox-default.ini
@@ -7,6 +7,9 @@ envlist =
     ansible-test, woke, codeql
 skipsdist = true
 skip_missing_interpreters = true
+# tox40 with latest venv doesn't work with py27 - cannot find interpreter
+# drop this once we can drop any/all support of py27
+requires = virtualenv<20.22.0
 
 [lsr_config]
 commands_pre =

--- a/tests/fixtures/test_tox_merge_ini/result.ini
+++ b/tests/fixtures/test_tox_merge_ini/result.ini
@@ -2,6 +2,7 @@
 envlist = mycustom1,mycustom2
 skipsdist = false
 skip_missing_interpreters = true
+requires = virtualenv<20.22.0
 sdistsrc = /tmp/somedir
 
 [lsr_config]

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ deps =
     tox30: tox==3.*
     py27: mock
 commands =
-    {env:SAFETY_CMD:safety} check -i 67599 -i 68477 -i 62044 -i 58755 -i 52495 -i 47833 -i 42559 -i 42218 -i 40291 -i 38765 -i 39611 -i 44492 -i 51457 -i 51499 --full-report  # ignore pip, PyYAML problems
+    {env:SAFETY_CMD:safety} check -i 70612 -i 67599 -i 68477 -i 62044 -i 58755 -i 52495 -i 47833 -i 42559 -i 42218 -i 40291 -i 38765 -i 39611 -i 44492 -i 51457 -i 51499 --full-report  # ignore pip, PyYAML problems
     pytest --cov=tox_lsr --cov-report=term-missing tests
     {env:COVERALLS_CMD:coveralls --output={envname}-coverage.txt}
 


### PR DESCRIPTION
virtualenv 20.22.0 and later do not support the creation of python 2.7
virtual envs, which is what tox uses to create venvs for py27 and related
tests.  So, restrict the version of virtualenv until we can completely
drop support for python 2.7
