### PR TITLE
several changes for python27, pylint, ansible-lint

### DIFF
--- a/src/tox_lsr/config_files/tox-default.ini
+++ b/src/tox_lsr/config_files/tox-default.ini
@@ -2,14 +2,11 @@
 [tox]
 envlist =
     black, pylint, flake8, yamllint
-    py{26,27,36,37,38,39,310,311}, shellcheck
+    py{26,27,36,38,39,310,311,312}, shellcheck
     collection, ansible-lint
     ansible-test, woke, codeql
 skipsdist = true
 skip_missing_interpreters = true
-# tox40 with latest venv doesn't work with py27 - cannot find interpreter
-# drop this once we can drop any/all support of py27
-requires = virtualenv<20.22.0
 
 [lsr_config]
 commands_pre =
@@ -35,10 +32,10 @@ setenv =
     LSR_TOX_ENV_TMP_DIR = {envtmpdir}
     LSR_SRC_OWNER = {env:LSR_SRC_OWNER:linux-system-roles}
 deps =
-    py{26,27,36,37,38,39,310,311}: pytest-cov
-    py{27,36,37,38,39,310,311}: pytest>=3.5.1
+    py{26,27,36,38,39,310,311,312}: pytest-cov
+    py{27,36,38,39,310,311,312}: pytest>=3.5.1
     py26: pytest
-    py{26,27,36,37,38,39,310,311}: -rpytest_extra_requirements.txt
+    py{26,27,36,38,39,310,311,312}: -rpytest_extra_requirements.txt
 allowlist_externals =
     bash
     mkdir
@@ -80,9 +77,6 @@ basepython = python2.7
 [testenv:py36]
 basepython = python3.6
 
-[testenv:py37]
-basepython = python3.7
-
 [testenv:py38]
 basepython = python3.8
 
@@ -94,6 +88,9 @@ basepython = python3.10
 
 [testenv:py311]
 basepython = python3.11
+
+[testenv:py312]
+basepython = python3.12
 
 [lsr_black]
 configfile = {lsr_configdir}/black.toml
@@ -119,9 +116,9 @@ basepython = python3
 passenv = RUN_PYLINT_*
 changedir = {toxinidir}
 deps =
-    {env:LSR_PYLINT_ANSIBLE_DEP:ansible-core==2.11.*}
+    {env:LSR_PYLINT_ANSIBLE_DEP:ansible-core==2.17.*}
     colorama
-    pylint>=1.8.4
+    pylint==3.1.0  # this is the version used by the latest ansible-test
     -rpylint_extra_requirements.txt
 commands =
     bash {lsr_scriptdir}/setup_module_utils.sh

--- a/src/tox_lsr/test_scripts/runcollection.sh
+++ b/src/tox_lsr/test_scripts/runcollection.sh
@@ -48,6 +48,9 @@ cd "$coll_path"
 
 # these are for ansible-lint
 cp "$LSR_CONFIGDIR/collection_yamllint.yml" "$coll_path/.yamllint.yml"
+# remove the extends: from yamllint so that the defaults from ansible-lint
+# will be used
+sed -e '/^extends:/d' -i "$coll_path/.yamllint.yml"
 touch "$coll_path/CHANGELOG.md"
 if [ -f "$TOXINIDIR"/.ansible-lint ]; then
   cp "$TOXINIDIR"/.ansible-lint "$coll_path"

--- a/tests/fixtures/test_tox_merge_ini/result.ini
+++ b/tests/fixtures/test_tox_merge_ini/result.ini
@@ -2,7 +2,6 @@
 envlist = mycustom1,mycustom2
 skipsdist = false
 skip_missing_interpreters = true
-requires = virtualenv<20.22.0
 sdistsrc = /tmp/somedir
 
 [lsr_config]
@@ -30,10 +29,10 @@ setenv = PYTHONPATH = {env:LSR_PYTHONPATH:}{toxinidir}/library:{toxinidir}/modul
 	LSR_SRC_OWNER = {env:LSR_SRC_OWNER:linux-system-roles}
 	LOCAL1 = local1
 	LOCAL2 = local2
-deps = py{26,27,36,37,38,39,310,311}: pytest-cov
-	py{27,36,37,38,39,310,311}: pytest>=3.5.1
+deps = py{26,27,36,38,39,310,311,312}: pytest-cov
+	py{27,36,38,39,310,311,312}: pytest>=3.5.1
 	py26: pytest
-	py{26,27,36,37,38,39,310,311}: -rpytest_extra_requirements.txt
+	py{26,27,36,38,39,310,311,312}: -rpytest_extra_requirements.txt
 	localdep1
 	localdep2
 allowlist_externals = bash
@@ -59,9 +58,6 @@ basepython = python2.7
 [testenv:py36]
 basepython = python3.6
 
-[testenv:py37]
-basepython = python3.7
-
 [testenv:py38]
 basepython = python3.8
 
@@ -73,6 +69,9 @@ basepython = python3.10
 
 [testenv:py311]
 basepython = python3.11
+
+[testenv:py312]
+basepython = python3.12
 
 [lsr_black]
 configfile = {lsr_configdir}/black.toml
@@ -95,9 +94,9 @@ configfile = {lsr_configdir}/pylintrc
 basepython = python3
 passenv = RUN_PYLINT_*
 changedir = {toxinidir}
-deps = {env:LSR_PYLINT_ANSIBLE_DEP:ansible-core==2.11.*}
+deps = {env:LSR_PYLINT_ANSIBLE_DEP:ansible-core==2.17.*}
 	colorama
-	pylint>=1.8.4
+	pylint==3.1.0  # this is the version used by the latest ansible-test
 	-rpylint_extra_requirements.txt
 commands = bash {lsr_scriptdir}/setup_module_utils.sh
 	{[lsr_config]commands_pre}


### PR DESCRIPTION
revert previous change for virtualenv - this broke some python3 testenvs

drop py37, add py312

use ansible-core 2.17 and pylint 3.1.0 for testenv pylint

This will require a change to the github action ci tests to use py39
for pylint (and flake8 and black)

remove extends: from yamllint to make it work with ansible-lint

The latest ansible-lint will automatically extend its configuration
with any .yamllint.yml found.  If you use "extends: default", it will
override this behavior.  Since we only use .yamllint.yml in conjunction
with ansible-lint, it is much better to just remove "extends: default"
from .yamllint.yml so that the built-in ansible-lint defaults will be
used.
