### PR TITLE
update ssh key from standard-inventory-qcow2

### DIFF
--- a/src/tox_lsr/osbuild-manifests/images/lsr.mpp.yml
+++ b/src/tox_lsr/osbuild-manifests/images/lsr.mpp.yml
@@ -5,12 +5,15 @@ mpp-vars:
   # mkpasswd -m sha512sum the_password
   root_password: $6$wj.kFDYpt.5Qi5R4$V0vLpJLmZu2G/gc5llsCTLM8C0KFb2ZUXiOyyFUVeZzpEA88d99iTayKbutE/zhxRAPRkubf.NvtsBdv/UxJm1
   # https://pagure.io/fork/rmeggins/standard-test-roles/blob/master/f/inventory/standard-inventory-qcow2#_59
-  root_ssh_key: "AAAAB3NzaC1yc2EAAAADAQABAAABAQDUOtNJdBEXyKxBB898rdT54ULjMGuO6v4jLX\
-    mRsdRhR5Id/lKNc9hsdioPWUePgYlqML2iSV72vKQoVhkyYkpcsjr3zvBny9+5xej3\
-    +TBLoEMAm2hmllKPmxYJDU8jQJ7wJuRrOVOnk0iSNF+FcY/yaQ0owSF02Nphx47j2K\
-    Wc0IjGGlt4fl0fmHJuZBA2afN/4IYIIsEWZziDewVtaEjWV3InMRLllfdqGMllhFR+\
-    ed2hQz9PN2QcapmEvUR4UCy/mJXrke5htyFyHi8ECfyMMyYeHwbWLFQIve4CWix9qt\
-    ksvKjcetnxT+WWrutdr3c9cfIj/c0v/Zg/c4zETxtp"
+  root_ssh_key: "AAAAB3NzaC1yc2EAAAADAQABAAABgQDF6DLa+l+ikW2PbJ8v++ooNjOYrzCDm1MRnz"\
+    "cs283W6u/3BYq2fejQ3xvtyh8rhMbqWdL89XlWs8yjdVgIAAoK1zbqEOM8N8IB5wBR"\
+    "o7dTIvtsc9/dIOEXSSBX5W2T6hGA/G6S1bsOrEFFnGiqWo16T99tsr8eR2ytgqFwaO"\
+    "9XO3mn2cEVkh0N0u57ls5/maGFipdW9GzLLL9AfQgfJaok90ZLm+2V0Qs3guZEjE75"\
+    "vSRHf5I1+leTHfUUbj0U984DYqQ3oaWQYjqaBX4wQu9ITSHPDOQ0HPKK1QL+7ar1Cr"\
+    "PwBaetqh7CMNr0fQiBQpHzsn7Mqy4XjCSUSLu2y6t/QHw48vj8jtaIbkV9g0eZJ3IN"\
+    "2oxKxx5Im0bInR0HN2pEKNKTu0btuASJKENFQzTRYDLVLfGPNCHbhox05bc0yxjrAs"\
+    "ngh0KW+aiqAEl6ld0SDijew0OQsegtEVTY4UUG5ms1RMixKnrxRCZDd0XEtkY+UyEk"\
+    "8nEnXt1JJ97MgHU="
   lsr_packages:  # base packages required for lsr and ansible
   - sudo # non-root access
   - openssh-server  # ssh access

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ deps =
     tox30: tox==3.*
     py27: mock
 commands =
-    {env:SAFETY_CMD:safety} check -i 70612 -i 67599 -i 68477 -i 62044 -i 58755 -i 52495 -i 47833 -i 42559 -i 42218 -i 40291 -i 38765 -i 39611 -i 44492 -i 51457 -i 51499 --full-report  # ignore pip, PyYAML problems
+    {env:SAFETY_CMD:safety} check -i 71064 -i 70612 -i 67599 -i 68477 -i 62044 -i 58755 -i 52495 -i 47833 -i 42559 -i 42218 -i 40291 -i 38765 -i 39611 -i 44492 -i 51457 -i 51499 --full-report  # ignore pip, PyYAML problems
     pytest --cov=tox_lsr --cov-report=term-missing tests
     {env:COVERALLS_CMD:coveralls --output={envname}-coverage.txt}
 


### PR DESCRIPTION
https://pagure.io/fork/rmeggins/standard-test-roles/blob/master/f/inventory/standard-inventory-qcow2#_59
was updated to use a 3072 bit key

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
