### PR TITLE
ci: Test Python 3.12 and 3.13

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -6,6 +6,7 @@ env:
 jobs:
   python:
     strategy:
+      fail-fast: false
       matrix:
         pyver_os:
           - ver: '2.7'

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -19,6 +19,10 @@ jobs:
             os: ubuntu-latest
           - ver: '3.11'
             os: ubuntu-latest
+          - ver: '3.12'
+            os: ubuntu-latest
+          - ver: '3.13'
+            os: ubuntu-latest
     runs-on: ${{ matrix.pyver_os.os }}
     steps:
       - name: checkout PR

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -13,8 +13,6 @@ jobs:
             os: ubuntu-20.04
           - ver: '3.6'
             os: ubuntu-20.04
-          - ver: '3.8'
-            os: ubuntu-latest
           - ver: '3.9'
             os: ubuntu-latest
           - ver: '3.10'

--- a/src/tox_lsr/utils.py
+++ b/src/tox_lsr/utils.py
@@ -6,7 +6,34 @@
 import os
 from typing import TYPE_CHECKING, cast
 
-import pkg_resources
+try:
+    # Python >= 3.9
+    import importlib.resources
+
+    def resource_filename(pkg, ref):
+        # type: (str, str) -> str
+        """Get path of a resource."""
+        return str(importlib.resources.files(pkg) / ref)
+
+    def resource_bytes(pkg, ref):
+        # type: (str, str) -> bytes
+        """Get file bytes of a resource."""
+        return (importlib.resources.files(pkg) / ref).read_bytes()
+
+except ImportError:
+    # Python 2
+    import pkg_resources
+
+    def resource_filename(pkg, ref):
+        # type: (str, str) -> str
+        """Get path of a resource."""
+        return pkg_resources.resource_filename(pkg, ref)
+
+    def resource_bytes(pkg, ref):
+        # type: (str, str) -> bytes
+        """Get file bytes of a resource."""
+        return pkg_resources.resource_string(pkg, ref)
+
 
 if TYPE_CHECKING:
     from tox.config import Config, Parser
@@ -100,7 +127,7 @@ def get_lsr_scriptdir():
     lsr_scriptdir = os.environ.get(LSR_SCRIPTDIR_ENV)
     if not lsr_scriptdir:
         # pylint: disable=consider-using-f-string
-        lsr_script_filename = pkg_resources.resource_filename(
+        lsr_script_filename = resource_filename(
             __name__,
             "{tsdir}/{tsname}".format(
                 tsdir=TEST_SCRIPTS_SUBDIR,
@@ -118,7 +145,7 @@ def get_lsr_configdir():
     lsr_configdir = os.environ.get(LSR_CONFIGDIR_ENV)
     if not lsr_configdir:
         # pylint: disable=consider-using-f-string
-        lsr_config_filename = pkg_resources.resource_filename(
+        lsr_config_filename = resource_filename(
             __name__,
             "{cfdir}/{cfname}".format(
                 cfdir=CONFIG_FILES_SUBDIR,
@@ -134,7 +161,7 @@ def get_lsr_default():
     """Get the content of tox-default.ini."""
 
     # pylint: disable=consider-using-f-string
-    return pkg_resources.resource_string(
+    return resource_bytes(
         __name__,
         "{cfdir}/{deftox}".format(
             cfdir=CONFIG_FILES_SUBDIR,

--- a/tests/unit/test_hooks3.py
+++ b/tests/unit/test_hooks3.py
@@ -16,8 +16,6 @@ except ImportError:
 
 from copy import deepcopy
 
-import pkg_resources
-
 # I have no idea why pylint complains about this.  This works:
 # command = python -c 'import py; print(dir(py.iniconfig))'
 # bug in pylint?  anyway, just ignore it
@@ -50,6 +48,7 @@ from tox_lsr.utils import (
     LSR_ENABLE,
     SCRIPT_NAME,
     TOX_DEFAULT_INI,
+    resource_bytes,
 )
 
 from .utils import MockConfig
@@ -62,10 +61,10 @@ class HooksTestCase(TestCase):
     def setUp(self):
         self.toxworkdir = tempfile.mkdtemp()
         patch(
-            "pkg_resources.resource_filename",
+            "tox_lsr.utils.resource_filename",
             return_value=self.toxworkdir + "/" + SCRIPT_NAME,
         ).start()
-        self.default_tox_ini_b = pkg_resources.resource_string(
+        self.default_tox_ini_b = resource_bytes(
             "tox_lsr", CONFIG_FILES_SUBDIR + "/" + TOX_DEFAULT_INI
         )
         self.default_tox_ini_raw = self.default_tox_ini_b.decode()
@@ -103,7 +102,7 @@ class HooksTestCase(TestCase):
         default_config = MockConfig(toxworkdir=self.toxworkdir)
 
         with patch(
-            "pkg_resources.resource_string",
+            "tox_lsr.utils.resource_bytes",
             return_value=self.default_tox_ini_b,
         ) as mock_rs:
             with patch("tox_lsr.hooks3.merge_config") as mock_mc:

--- a/tox.ini
+++ b/tox.ini
@@ -67,6 +67,7 @@ deps =
     unittest2
     pylint
     py
+    setuptools
 commands =
     pylint setup.py src/tox_lsr
     pylint -d C0115,C0116,C0321,E0611,R0903,W0613 \

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ deps =
     tox30: tox==3.*
     py27: mock
 commands =
-    {env:SAFETY_CMD:safety} check -i 72236 -i 73456 -i 72132 -i 71064 -i 70612 -i 67599 -i 68477 -i 62044 -i 58755 -i 52495 -i 47833 -i 42559 -i 42218 -i 40291 -i 38765 -i 39611 -i 44492 -i 51457 -i 51499 --full-report  # ignore pip, PyYAML problems
+    {env:SAFETY_CMD:safety} check -i 72236 -i 73456 -i 72132 -i 71064 -i 70612 -i 67599 -i 68477 -i 62044 -i 58755 -i 52495 -i 47833 -i 42559 -i 42218 -i 40291 -i 38765 -i 39611 -i 44492 -i 51457 -i 51499 -i 75180 --full-report  # ignore pip, PyYAML problems
     pytest --cov=tox_lsr --cov-report=term-missing tests
     {env:COVERALLS_CMD:coveralls --output={envname}-coverage.txt}
 

--- a/tox.ini
+++ b/tox.ini
@@ -83,7 +83,10 @@ commands =
 
 [testenv:flake8]
 envdir = {[linters]envdir}
-basepython = {[linters]basepython}
+# HACK: flake8 fails with AttributeError: 'EntryPoints' object has no attribute 'get' on newer Pythons
+# see https://github.com/PyCQA/flake8/issues/1701 and https://github.com/python/importlib_metadata/issues/406
+basepython = python3.11
+# basepython = {[linters]basepython}
 description =
     {envname}: Run style checks
 deps =


### PR DESCRIPTION
See https://github.com/linux-system-roles/sudo/pull/47#issuecomment-2777886090 

I wasted two hours on trying to fix flake8 with current Python, and then gave up. I'm afraid I can't offer knowledge from Cockpit or my python-dbusmock either, as we/I abandoned flake8 a long time ago in favor of [ruff](https://docs.astral.sh/ruff/). If this hack isn't acceptable to you, perhaps you have  better idea how to fix it? Thanks!