### PR TITLE
bump to version 3.5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import find_packages, setup
 # pylint: disable=R1732
 setup(
     name="tox-lsr",
-    version="3.4.0",
+    version="3.5.0",
     url="https://github.com/linux-system-roles/tox-lsr",
     description="A tox plugin for testing Linux system roles",
     long_description_content_type="text/markdown",

--- a/src/tox_lsr/version.py
+++ b/src/tox_lsr/version.py
@@ -3,4 +3,4 @@
 #
 """Holds tox-lsr plugin version."""
 
-__version__ = "3.4.0"
+__version__ = "3.5.0"


### PR DESCRIPTION
I noticed your tags don't have any content. How about we use them for some release note summary: I propose something based on `git shortlog 3.4.0..`:

```
3.5.0

- Test Python 3.12 and 3.13
- Handle format change of osbuild --store output
- Add cs10, f40 osbuild ipp.yml
- Update ssh key from standard-inventory-qcow2
```