### PR TITLE
ci: remove dependency on fmf

### DIFF
--- a/src/tox_lsr/config_files/tox-default.ini
+++ b/src/tox_lsr/config_files/tox-default.ini
@@ -294,7 +294,6 @@ basepython = python3
 setenv =
     {[testenv]setenv}
 deps =
-    fmf  # needed for standard-inventory-qcow2
     productmd  # needed for runqemu
     PyYAML  # needed for runqemu
     ruamel.yaml  # needed for collection support

--- a/tests/fixtures/test_tox_merge_ini/result.ini
+++ b/tests/fixtures/test_tox_merge_ini/result.ini
@@ -233,8 +233,7 @@ commands = bash {lsr_scriptdir}/runcodeql.sh
 changedir = {toxinidir}
 basepython = python3
 setenv = {[testenv]setenv}
-deps = fmf  # needed for standard-inventory-qcow2
-	productmd  # needed for runqemu
+deps = productmd  # needed for runqemu
 	PyYAML  # needed for runqemu
 	ruamel.yaml  # needed for collection support
 	beautifulsoup4  # needed for centoshtml support


### PR DESCRIPTION
Since https://pagure.io/fork/rmeggins/standard-test-roles/c/187955ce6b1491c64ade51faca8446de402c6695?branch=linux-system-roles
We do not need to install fmf

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
