### PR TITLE
ci: Use package instead of file name for package resources

### DIFF
--- a/src/tox_lsr/utils.py
+++ b/src/tox_lsr/utils.py
@@ -128,7 +128,7 @@ def get_lsr_scriptdir():
     if not lsr_scriptdir:
         # pylint: disable=consider-using-f-string
         lsr_script_filename = resource_filename(
-            __name__,
+            __package__,
             "{tsdir}/{tsname}".format(
                 tsdir=TEST_SCRIPTS_SUBDIR,
                 tsname=SCRIPT_NAME,
@@ -146,7 +146,7 @@ def get_lsr_configdir():
     if not lsr_configdir:
         # pylint: disable=consider-using-f-string
         lsr_config_filename = resource_filename(
-            __name__,
+            __package__,
             "{cfdir}/{cfname}".format(
                 cfdir=CONFIG_FILES_SUBDIR,
                 cfname=CONFIG_NAME,
@@ -162,7 +162,7 @@ def get_lsr_default():
 
     # pylint: disable=consider-using-f-string
     return resource_bytes(
-        __name__,
+        __package__,
         "{cfdir}/{deftox}".format(
             cfdir=CONFIG_FILES_SUBDIR,
             deftox=TOX_DEFAULT_INI,


### PR DESCRIPTION
Unlike `pkg_resources`, `importlib.resources` cannot be called with a module name inside of a package, like `tox_lsr.utils`, that fails with

> TypeError: 'tox_lsr.utils' is not a package

For some reason that doesn't break the tests here, but it does break in consumers like the sudo role's tests.

So always request the package resources from the package intead of the module.

---

This fixes the failures in https://github.com/linux-system-roles/sudo/pull/47 especially [this one](https://github.com/linux-system-roles/sudo/actions/runs/14333183921/job/40173732854?pr=47). I can reproduce this locally with

```
sudo pip install ~/upstream/lsr/tox-lsr/ && tox -e py311
```
in the lsr-sudo checkout, and it passes now.