### PR TITLE
ci: Move Python 2.7 test to Ubuntu 22.04 host, run python 3.6 test in UBI8 container

### DIFF
--- a/.github/workflows/tox-py36.yml
+++ b/.github/workflows/tox-py36.yml
@@ -1,0 +1,24 @@
+name: tox
+on:  # yamllint disable-line rule:truthy
+  - pull_request
+permissions:
+  contents: read
+jobs:
+  py36:
+    runs-on: ubuntu-latest
+    container: registry.access.redhat.com/ubi8/ubi
+    steps:
+      - name: Set up Python 3.6 and pip
+        run: dnf install -y git-core python3-pip
+
+      - name: checkout PR
+        uses: actions/checkout@v4
+
+      - name: Install platform dependencies, python, tox
+        run: |
+          set -euxo pipefail
+          python3 -m pip install --upgrade pip
+          pip install -rtox-requirements.txt
+
+      - name: Run tox tests
+        run: tox -e py36,coveralls

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -11,8 +11,7 @@ jobs:
         pyver_os:
           - ver: '2.7'
             os: ubuntu-22.04
-          - ver: '3.6'
-            os: ubuntu-20.04
+          # 3.6 gets tested in tox-py36.yml
           - ver: '3.9'
             os: ubuntu-latest
           - ver: '3.10'

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         pyver_os:
           - ver: '2.7'
-            os: ubuntu-20.04
+            os: ubuntu-22.04
           - ver: '3.6'
             os: ubuntu-20.04
           - ver: '3.9'


### PR DESCRIPTION
The "ubuntu-20.04" runner will be switched off in a week, and is currently browning out.

See https://github.com/actions/runner-images/issues/11101.

---

See the annotation in e.g. https://github.com/linux-system-roles/tox-lsr/actions/runs/14334537098/job/40179317006?pr=181