### PR TITLE
feat: add --make-batch-file-order

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,6 +649,13 @@ You must specify the trailing `--` on the command line to tell runqemu that
 there are no more arguments.  You can then edit the `batch.txt` file to remove
 files, change arguments, etc. and re-run using `--batch-file batch.txt`.
 
+By default, `--make-batch` will sort the list of test files in `alphanum` which
+is US ASCII sort order (using the python `sorted` function).  If you want to use
+a different sort order, use `--make-batch-file-order ORDER`.  Currently, the
+only other `ORDER` is `natural` which is the default filesystem order (whatever
+is the order returned by `glob("tests/tests_*.yml")`).  Note that when you
+specify `--make-batch-file-order`, that implies `--make-batch`.
+
 Only the following `runqemu` arguments are supported in batch files:
 `--log-file`, `--artifacts`, `--setup-yml`, `--tests-dir`, `--cleanup-yml`, and
 `--debug` (only on last line). In addition, there is an argument used only in


### PR DESCRIPTION
By default, `--make-batch` will sort the list of test files in `alphanum` which
is US ASCII sort order (using the python `sorted` function).  If you want to use
a different sort order, use `--make-batch-file-order ORDER`.  Currently, the
only other `ORDER` is `natural` which is the default filesystem order (whatever
is the order returned by `glob("tests/tests_*.yml")`).  Note that when you
specify `--make-batch-file-order`, that implies `--make-batch`.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
