### PR TITLE
container tests: Cleanups, fixes, and bootc mode

### DIFF
--- a/src/tox_lsr/test_scripts/runcontainer.sh
+++ b/src/tox_lsr/test_scripts/runcontainer.sh
@@ -172,6 +172,10 @@ refresh_test_container() {
         *-9) pkgcmd=dnf ;
              initpkgs=systemd ;
              prepkgs="dnf-plugins-core" ;;
+        fedora-40) pkgcmd=dnf ;
+                   prepkgs="" ;;
+        fedora-*) pkgcmd=dnf ;
+                  prepkgs="python3-libdnf5" ;;
         *) pkgcmd=dnf; prepkgs="" ;;
         esac
         for rpm in ${EXTRA_RPMS:-}; do

--- a/src/tox_lsr/test_scripts/runcontainer.sh
+++ b/src/tox_lsr/test_scripts/runcontainer.sh
@@ -341,11 +341,13 @@ run_playbooks() {
                 -e ansible_playbook_filepath="$(type -p ansible-playbook)" "$pb"
         done
     else
-        # shellcheck disable=SC2086
-        ansible-playbook -vv ${CONTAINER_SKIP_TAGS:-} ${EXTRA_SKIP_TAGS:-} \
-            -i "$inv_file" ${vault_args:-} \
-            -e ansible_playbook_filepath="$(type -p ansible-playbook)" \
-            "${test_pbs[@]}"
+        for pb in "${test_pbs[@]}"; do
+            # shellcheck disable=SC2086
+            ansible-playbook -vv ${CONTAINER_SKIP_TAGS:-} ${EXTRA_SKIP_TAGS:-} \
+                -i "$inv_file" ${vault_args:-} \
+                -e ansible_playbook_filepath="$(type -p ansible-playbook)" \
+                "$pb"
+        done
     fi
     popd > /dev/null
 }


### PR DESCRIPTION
We don't currently run the container-* env tests in CI. They have some troubles, which this PR fixes. I'm not sure that we actually want to add test runs for the "classic" images (as we already have QEMU), but I want to use the machinery at least for bootc container test runs.

I put it all together in my fork, you can [see a successful run here](https://github.com/martinpitt/lsr-sudo/actions/runs/14615961638/job/41004496814). But I want to clean that up a little further before I send a PR against sudo.

If you think this is too much to land already, I'm also happy to send the fixes (i.e. all commits but the topmost one) as a separate PR.

Let's use this PR to discuss the general approach?

https://issues.redhat.com/browse/RHEL-85652

 - [x] Requires https://github.com/linux-system-roles/linux-system-roles.github.io/pull/121

