### PR TITLE
runcontainer: Add python3-libdnf5 workaround for Fedora bootc images, Skip containers.podman installation if it already exists

### DIFF
--- a/src/tox_lsr/test_scripts/runcontainer.sh
+++ b/src/tox_lsr/test_scripts/runcontainer.sh
@@ -362,6 +362,7 @@ run_playbooks() {
         run_buildah "$test_pb_base"
         # tmpdir hack: https://issues.redhat.com/browse/BIFROST-726
         echo "sut ansible_host=$container_id ansible_connection=buildah ansible_remote_tmp=/tmp" > "$inv_file"
+        CONTAINER_SKIP_TAGS="${CONTAINER_SKIP_TAGS:-} --skip-tags tests::booted"
     else
         run_podman "$test_pb_base"
         echo "sut ansible_host=$container_id ansible_connection=podman" > "$inv_file"


### PR DESCRIPTION
The Fedora bootc base images are lacking python3-libdnf5, which breaks Ansible's `package:`. Add this manually for the tests for the time being, until it gets added officially [1]. This unblocks us for fixing our roles on Fedora bootc container builds without having to copy this workaround to all roles.

[1] https://gitlab.com/fedora/bootc/base-images/-/merge_requests/167

----

Tested locally with 
```
sudo pip install ~/upstream/lsr/tox-lsr/ && LSR_CONTAINER_PROFILE=false LSR_CONTAINER_PRETTY=false tox -e container-ansible-core-2.17 -- --image-name fedora-42-bootc tests/tests_default.yml
```

and validated that it doesn't break centos-9-bootc. I also put this into https://github.com/linux-system-roles/sudo/pull/52 and https://github.com/linux-system-roles/cockpit/pull/212 which proves that this works.