### PR TITLE
bump version to 3.7.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import find_packages, setup
 # pylint: disable=R1732
 setup(
     name="tox-lsr",
-    version="3.6.0",
+    version="3.7.0",
     url="https://github.com/linux-system-roles/tox-lsr",
     description="A tox plugin for testing Linux system roles",
     long_description_content_type="text/markdown",

--- a/src/tox_lsr/version.py
+++ b/src/tox_lsr/version.py
@@ -3,4 +3,4 @@
 #
 """Holds tox-lsr plugin version."""
 
-__version__ = "3.6.0"
+__version__ = "3.7.0"


### PR DESCRIPTION
I'd like to push out the container test updates, makes it easier to roll them out to our roles and start testing/fixing.