### PR TITLE
runcontainer: Disable ansible_become

### DIFF
--- a/src/tox_lsr/test_scripts/runcontainer.sh
+++ b/src/tox_lsr/test_scripts/runcontainer.sh
@@ -361,11 +361,11 @@ run_playbooks() {
     if [ -n "$BOOTC_MODE" ]; then
         run_buildah "$test_pb_base"
         # tmpdir hack: https://issues.redhat.com/browse/BIFROST-726
-        echo "sut ansible_host=$container_id ansible_connection=buildah ansible_remote_tmp=/tmp" > "$inv_file"
+        echo "sut ansible_host=$container_id ansible_connection=buildah ansible_become=false ansible_remote_tmp=/tmp" > "$inv_file"
         CONTAINER_SKIP_TAGS="${CONTAINER_SKIP_TAGS:-} --skip-tags tests::booted"
     else
         run_podman "$test_pb_base"
-        echo "sut ansible_host=$container_id ansible_connection=podman" > "$inv_file"
+        echo "sut ansible_host=$container_id ansible_connection=podman ansible_become=false" > "$inv_file"
     fi
 
     if [ -z "$container_id" ]; then


### PR DESCRIPTION
When running firewalld container tests in GitHub actions, all the tests mysteriously fail right at the start in `gather_facts` with:

> "ansible.legacy.setup": {"ansible_facts": {"failed": true, "module_stderr":
> "sudo: PAM account management error: Authentication service cannot retrieve authentication info\nsudo: a password is required

It's not really clear where this comes from -- neither the GitHub running host nor the buildah (for bootc) / podman (for classic rpm) container requires a sudo password.

However, we can entirely avoid that: We never expect (or want) to run `sudo` in containers, as all playbooks are expected to run as root already.

----

See [this failed run](https://github.com/martinpitt/lsr-firewall/actions/runs/14658995041/job/41139103829#step:12:115) (it also happens in all the -bootc and centos 9 rpm tests). I pulled this fix into [this run](https://github.com/martinpitt/lsr-firewall/actions/runs/14660587695/job/41143957331) and it looks much better now -- it succeeds on F41/F42 and just fails in CentOS 9 on some entirely unrelated reason.