### PR TITLE
runcontainer: Add python3-rpm to Fedora test containers

### DIFF
--- a/src/tox_lsr/test_scripts/runcontainer.sh
+++ b/src/tox_lsr/test_scripts/runcontainer.sh
@@ -193,7 +193,7 @@ yaml.safe_dump(val, open(sys.argv[2], "w"))
     fedora-40) pkgcmd=dnf ;
                 prepkgs="" ;;
     fedora-*) pkgcmd=dnf ;
-                prepkgs="python3-libdnf5" ;;
+                prepkgs="python3-libdnf5 python3-rpm" ;;
     *) pkgcmd=dnf; prepkgs="" ;;
     esac
     for rpm in ${EXTRA_RPMS:-}; do
@@ -339,7 +339,7 @@ run_buildah() {
     CONTAINER_CLEANUP="buildah rm $container_id"
     # HACK: Until https://gitlab.com/fedora/bootc/base-images/-/merge_requests/167 lands
     if echo "$CONTAINER_BASE_IMAGE" | grep -q 'fedora-.*bootc'; then
-        buildah run "$container_id" -- dnf install -y python3-libdnf5
+        buildah run "$container_id" -- dnf install -y python3-libdnf5 python3-rpm
     fi
 }
 


### PR DESCRIPTION
This is needed by Ansible's `package_facts:`. It otherwise fails with

> fatal: [sut]: FAILED! => {"changed": false, "msg": "Could not detect a supported package manager from the following list: ['pkg_info', 'portage', 'pacman', 'rpm', 'apk', 'pkg', 'apt'], or the required Python library is not installed. Check warnings for details."}

Same problem in bootc containers, so add it there as well. Also added to https://gitlab.com/fedora/bootc/base-images/-/merge_requests/167

---

See [this failed test run](https://github.com/martinpitt/lsr-logging/actions/runs/14702215530/job/41253784336#step:12:341) on my logging role fork. This breaks almost all tests in containers.