### PR TITLE
runcontainer: Fix /root directory in bootc images

### DIFF
--- a/src/tox_lsr/test_scripts/runcontainer.sh
+++ b/src/tox_lsr/test_scripts/runcontainer.sh
@@ -341,6 +341,8 @@ run_buildah() {
     if echo "$CONTAINER_BASE_IMAGE" | grep -q 'fedora-.*bootc'; then
         buildah run "$container_id" -- dnf install -y python3-libdnf5 python3-rpm
     fi
+    # HACK: fix /root directory https://issues.redhat.com/browse/BIFROST-726
+    buildah run "$container_id" -- mkdir -p /var/roothome
 }
 
 run_playbooks() {


### PR DESCRIPTION
Some roles such as mssql require the /root directory to actually exist. Create it, to work around https://issues.redhat.com/browse/BIFROST-726

---

This gets us over the initial [complete early failure](https://github.com/martinpitt/lsr-mssql/actions/runs/14835409745) due to 
```
fatal: [sut]: FAILED! => {
    "attempts": 3,
    "changed": false,
    "invocation": {
        "module_args": {
            "fingerprint": null,
            "key": "https://packages.microsoft.com/keys/microsoft.asc",
            "state": "present",
            "validate_certs": true
        }
    },
    "msg": "gpg: Fatal: can't create directory '/root/.gnupg': No such file or directory\n"
}
```

Tested locally with the mssql role, and it gets further now.