### PR TITLE
feat: Sort QEMU batch tests in ascending or descending order by image name

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,12 +649,19 @@ You must specify the trailing `--` on the command line to tell runqemu that
 there are no more arguments.  You can then edit the `batch.txt` file to remove
 files, change arguments, etc. and re-run using `--batch-file batch.txt`.
 
-By default, `--make-batch` will sort the list of test files in `alphanum` which
-is US ASCII sort order (using the python `sorted` function).  If you want to use
-a different sort order, use `--make-batch-file-order ORDER`.  Currently, the
-only other `ORDER` is `natural` which is the default filesystem order (whatever
-is the order returned by `glob("tests/tests_*.yml")`).  Note that when you
-specify `--make-batch-file-order`, that implies `--make-batch`.
+By default, `--make-batch` will sort the list of test files in `imagehash`
+order. If you want to use a different order, use `--make-batch-file-order ORDER`.
+Supported `ORDER` values are:
+
+ - `ascending`: US ASCII sort order (using Python's `sorted()` function)
+ - `descending`: reverse  US ASCII sort order
+ - `imagehash`: `ascending` or `descending` depending on an 1-bit hash of the
+   image name; this is a good compromise between avoiding test dependencies and
+   still keeping a reproducible order
+ - `natural`: default filesystem order (whatever is the order returned by
+   `glob("tests/tests_*.yml")`)
+
+Note that when you specify `--make-batch-file-order`, that implies `--make-batch`.
 
 Only the following `runqemu` arguments are supported in batch files:
 `--log-file`, `--artifacts`, `--setup-yml`, `--tests-dir`, `--cleanup-yml`, and


### PR DESCRIPTION
Commit 2369683 sorted the batch tests in ascending order by default to make test results more predictable and reproducible locally.

However, this makes the tests prone to introducing dependencies/cleanup failures. We want to run some (ideally: half of) the tests in reverse order to uncover that but still keep the reproducibility.

Introduce a new batch order mode `imagehash` which maps the image name to one bit and use ascending/descending mode according to it. This makes e.g. "fedora-42" use ascending and "centos-10" use descending order.

For completeness, introduce a `descending` order as well, and rename the existing `alphanum` to `ascending` (as `revalphanum` gets a bit unwieldy).

https://issues.redhat.com/browse/RHELMISC-11615

----

Tested in sudo rule. `fedora-42` is ascending:
```
❱❱❱ git clean -fdx; sudo pip install ~/upstream/lsr/tox-lsr/ && tox -e qemu-ansible-core-2.17 -- --image-name fedora-42 --log-level=debug --make-batch
INFO:root:Running playbooks ['/var/home/martin/upstream/lsr/sudo/tests/tests_check_if_configured.yml']
INFO:root:Running playbooks ['/var/home/martin/upstream/lsr/sudo/tests/tests_default.yml']
INFO:root:Running playbooks ['/var/home/martin/upstream/lsr/sudo/tests/tests_include_vars_from_parent.yml']
INFO:root:Running playbooks ['/var/home/martin/upstream/lsr/sudo/tests/tests_large_configuration.yml']
INFO:root:Running playbooks ['/var/home/martin/upstream/lsr/sudo/tests/tests_multiple_sudoers.yml']
INFO:root:Running playbooks ['/var/home/martin/upstream/lsr/sudo/tests/tests_role_applied.yml']

❱❱❱ cat batch.txt 
--tests-dir tests --log-file tests/tests_check_if_configured.yml.log -- tests/tests_check_if_configured.yml
--tests-dir tests --log-file tests/tests_default.yml.log -- tests/tests_default.yml
--tests-dir tests --log-file tests/tests_include_vars_from_parent.yml.log -- tests/tests_include_vars_from_parent.yml
--tests-dir tests --log-file tests/tests_large_configuration.yml.log -- tests/tests_large_configuration.yml
--tests-dir tests --log-file tests/tests_multiple_sudoers.yml.log -- tests/tests_multiple_sudoers.yml
--tests-dir tests --log-file tests/tests_role_applied.yml.log -- tests/tests_role_applied.yml
```

`centos-10` is descending:
```
❱❱❱ tox -e qemu-ansible-core-2.17 -- --image-name centos-10 --log-level=debug --make-batch
INFO:root:Running playbooks ['/var/home/martin/.cache/linux-system-roles/centos-10_setup.yml', '/var/home/martin/upstream/lsr/sudo/tests/tests_role_applied.yml']
INFO:root:Running playbooks ['/var/home/martin/.cache/linux-system-roles/centos-10_setup.yml', '/var/home/martin/upstream/lsr/sudo/tests/tests_multiple_sudoers.yml']
INFO:root:Running playbooks ['/var/home/martin/.cache/linux-system-roles/centos-10_setup.yml', '/var/home/martin/upstream/lsr/sudo/tests/tests_large_configuration.yml']
INFO:root:Running playbooks ['/var/home/martin/.cache/linux-system-roles/centos-10_setup.yml', '/var/home/martin/upstream/lsr/sudo/tests/tests_include_vars_from_parent.yml']
INFO:root:Running playbooks ['/var/home/martin/.cache/linux-system-roles/centos-10_setup.yml', '/var/home/martin/upstream/lsr/sudo/tests/tests_default.yml']
INFO:root:Running playbooks ['/var/home/martin/.cache/linux-system-roles/centos-10_setup.yml', '/var/home/martin/upstream/lsr/sudo/tests/tests_check_if_configured.yml']

❱❱❱ cat batch.txt 
--tests-dir tests --log-file tests/tests_role_applied.yml.log -- tests/tests_role_applied.yml
--tests-dir tests --log-file tests/tests_multiple_sudoers.yml.log -- tests/tests_multiple_sudoers.yml
--tests-dir tests --log-file tests/tests_large_configuration.yml.log -- tests/tests_large_configuration.yml
--tests-dir tests --log-file tests/tests_include_vars_from_parent.yml.log -- tests/tests_include_vars_from_parent.yml
--tests-dir tests --log-file tests/tests_default.yml.log -- tests/tests_default.yml
--tests-dir tests --log-file tests/tests_check_if_configured.yml.log -- tests/tests_check_if_configured.yml
```

I am happy to bikeshed about the `ORDER` names. If you prefer to keep the current `alphanum` and add `revalphanum` and `imagealphanum` or so, I'm fine with that. The main thing I care about is that we change the `--make-batch` default, so that we don't have to change all the workflows. This change is already gated on updating tox-lsr release , so we will get PRs where we can fix tests if necessary.