### PR TITLE
bump version to 3.9.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import find_packages, setup
 # pylint: disable=R1732
 setup(
     name="tox-lsr",
-    version="3.8.0",
+    version="3.9.0",
     url="https://github.com/linux-system-roles/tox-lsr",
     description="A tox plugin for testing Linux system roles",
     long_description_content_type="text/markdown",

--- a/src/tox_lsr/version.py
+++ b/src/tox_lsr/version.py
@@ -3,4 +3,4 @@
 #
 """Holds tox-lsr plugin version."""
 
-__version__ = "3.8.0"
+__version__ = "3.9.0"


### PR DESCRIPTION
Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Bump tox-lsr plugin version to 3.9.0.

Chores:
- Update version in setup.py from 3.8.0 to 3.9.0
- Update __version__ in version.py from 3.8.0 to 3.9.0