### PR TITLE
runcontainer: Skip reboot tests; tests: fix mypy

### DIFF
--- a/src/tox_lsr/test_scripts/runcontainer.sh
+++ b/src/tox_lsr/test_scripts/runcontainer.sh
@@ -364,10 +364,12 @@ run_playbooks() {
         run_buildah "$test_pb_base"
         # tmpdir hack: https://issues.redhat.com/browse/BIFROST-726
         echo "sut ansible_host=$container_id ansible_connection=buildah ansible_become=false ansible_remote_tmp=/tmp" > "$inv_file"
-        CONTAINER_SKIP_TAGS="${CONTAINER_SKIP_TAGS:-} --skip-tags tests::booted"
+        CONTAINER_SKIP_TAGS="${CONTAINER_SKIP_TAGS:-} --skip-tags tests::booted,tests::reboot"
     else
         run_podman "$test_pb_base"
         echo "sut ansible_host=$container_id ansible_connection=podman ansible_become=false" > "$inv_file"
+        # reboot does not work in systemd containers, it just stops them
+        CONTAINER_SKIP_TAGS="${CONTAINER_SKIP_TAGS:-} --skip-tags tests::reboot"
     fi
 
     if [ -z "$container_id" ]; then

--- a/tox.ini
+++ b/tox.ini
@@ -103,7 +103,7 @@ description =
     {envname}: Run type checks
 deps =
     py
-    types-setuptools
+    setuptools>=71
     tox
     mypy
 commands =


### PR DESCRIPTION
Running `reboot` in a podman system container does not work -- it just shuts down and stops the container, but never restarts it. So skip these tests during container runs.

Also skip them in container builds. This is a bit redundant as there is also `tests::booted`, but it's easier and more symmetric.

---

This will fix [crypto-policies container runs](https://github.com/martinpitt/lsr-crypto_policies/actions/runs/15161365400/job/42628047869). I pulled this PR into my fork, and it [passes](https://github.com/martinpitt/lsr-crypto_policies/actions/runs/15161943002/job/42629926828).

## Summary by Sourcery

Skip reboot tests in container-based CI due to reboot not supported in system containers

Enhancements:
- Expand buildah container runs to skip both tests::booted and tests::reboot
- Add skip tag for tests::reboot in podman container runs for symmetry