### PR TITLE
bump version to 3.9.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import find_packages, setup
 # pylint: disable=R1732
 setup(
     name="tox-lsr",
-    version="3.9.0",
+    version="3.9.1",
     url="https://github.com/linux-system-roles/tox-lsr",
     description="A tox plugin for testing Linux system roles",
     long_description_content_type="text/markdown",

--- a/src/tox_lsr/version.py
+++ b/src/tox_lsr/version.py
@@ -3,4 +3,4 @@
 #
 """Holds tox-lsr plugin version."""
 
-__version__ = "3.9.0"
+__version__ = "3.9.1"


### PR DESCRIPTION
I'd like to do a release to enable container tests for crypto-policies role.

## Summary by Sourcery

Enhancements:
- Bump version in setup.py and version.py to 3.9.1