### PR TITLE
change repo urls to point to vault

### DIFF
--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -1,9 +1,10 @@
 FROM quay.io/centos/centos:centos7
 
-RUN yum update -y && PKGS="centos-release-ansible-29" && \
+RUN sed -i '/^mirror/d;s,#\(baseurl=http://\)mirror,\1vault,' /etc/yum.repos.d/*.repo && \
+    yum update -y && PKGS="centos-release-ansible-29" && \
     yum install -y $PKGS && rpm -V $PKGS && \
+    sed -i '/^mirror/d;s,#\(baseurl=http://\)mirror,\1vault,' /etc/yum.repos.d/*.repo && \
     PKGS="ansible openssh-clients" && \
-    yum -y install $PKGS && rpm -V $PKGS && \
-    yum clean all
+    yum -y install $PKGS && rpm -V $PKGS && yum clean all
 
 ENTRYPOINT ["/usr/bin/ansible-playbook"]


### PR DESCRIPTION
Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Enhancements:
- Replace mirror base URLs with vault in yum repo configuration in Dockerfile