### PR TITLE
feat: Add script to turn a buildah container into a QEMU image

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,6 +733,10 @@ ansible-vault encrypt_string --vault-password-file tests/vault_pwd \
   --stdin-name sudo_password >> tests/vars/vault-variables.yml
 ```
 
+Do this to run bootc end-to-end tests which call
+[bootc-buildah-qcow.sh](./src/tox_lsr/test_scripts/bootc-buildah-qcow.sh),
+unless your system has passwordless sudo.
+
 Then if you run
 ```
 tox -e qemu-... -- --image-name name tests/tests_that_uses_my_secret_value.yml

--- a/README.md
+++ b/README.md
@@ -724,6 +724,15 @@ ansible-vault encrypt_string --vault-password-file tests/vault_pwd my_secret_val
 ansible-vault encrypt_string --vault-password-file tests/vault_pwd another_value \
   --name another_var >> tests/vars/vault-variables.yml
 ```
+
+To prevent sensitive content like your sudo password from being written into
+your `~/.bash_history`, you can also type the password on standard input:
+
+```
+ansible-vault encrypt_string --vault-password-file tests/vault_pwd \
+  --stdin-name sudo_password >> tests/vars/vault-variables.yml
+```
+
 Then if you run
 ```
 tox -e qemu-... -- --image-name name tests/tests_that_uses_my_secret_value.yml

--- a/src/tox_lsr/test_scripts/bootc-buildah-qcow.sh
+++ b/src/tox_lsr/test_scripts/bootc-buildah-qcow.sh
@@ -1,0 +1,102 @@
+#!/bin/sh
+# Build a qcow2 image from a bootc buildah container
+# resulting image will be in tmp/<buildah id>/qcow2/disk.qcow2
+# Usage: build-buildah-qcow.sh <buildah id>
+set -eu
+
+BUILDAH_ID="$1"
+
+MYDIR=$(dirname $0)
+OCI_TAG="localhost/bootc-tmp:$BUILDAH_ID"
+
+# extract private SSH key from standard-inventory-qcow2, and generate pubkey from it
+# keep this in sync with ./runqemu.py
+INVENTORY_URL="https://pagure.io/fork/rmeggins/standard-test-roles/raw/linux-system-roles/f/inventory/standard-inventory-qcow2"
+INVENTORY="${TOX_WORK_DIR:-.tox}/standard-inventory-qcow2"
+[ -e "$INVENTORY" ] || curl --fail -o "$INVENTORY" "$INVENTORY_URL"
+
+PUBKEY=$(sed -n '/BEGIN.*PRIVATE KEY/,/END.*PRIVATE KEY/ { s/^.*"""//; p }' \
+    "$INVENTORY" | ssh-keygen -y -f /dev/stdin)
+
+# user's or system podman storage location
+STORAGE=$(podman info -f '{{.Store.GraphRoot}}')
+
+OS_RELEASE=$(buildah run "$BUILDAH_ID" cat /etc/os-release)
+
+# buildah → container image
+buildah commit "$BUILDAH_ID" "$OCI_TAG"
+# always clean up the temporary tag
+trap "podman rmi $OCI_TAG" EXIT INT QUIT PIPE
+
+# invoke booc-image-builder
+rm -rf tmp
+OUTPUT="./tmp/$BUILDAH_ID"
+mkdir -p "$OUTPUT"
+
+cat <<EOF > tmp/bib.config.json
+{
+    "blueprint": {
+        "customizations": {
+            "user": [
+                {"name": "root", "password": "foobar", "key": "$PUBKEY"}
+            ]
+        }
+    }
+}
+EOF
+
+# for local development, support adding "sudo_password" to the vault, see README.md
+# not necessary for e.g. GitHub actions which has passwordless sudo
+if [ -e vault_pwd ] && [ -e vars/vault-variables.yml ]; then
+    export SUDO_ASKPASS="$MYDIR/vault-sudo-askpass.sh"
+fi
+
+# boot-cimage-builder must be run as root container; also support breaking out of toolbox
+AM_ROOT=
+if systemd-detect-virt --quiet --container; then
+    if [ -n "${SUDO_ASKPASS:-}" ]; then
+        # the helper is in toolbox, not the host; so we can only feed the password via stdin
+        run_root() { "$SUDO_ASKPASS" | flatpak-spawn --host sudo -S -- "$@"; }
+    else
+        # best-effort: won't work in Ansible (no stdin), but for interactive calling
+        run_root() { flatpak-spawn --host sudo -S -- "$@"; }
+    fi
+elif [ "$(id -u)" != 0 ]; then
+    if [ -n "${SUDO_ASKPASS:-}" ]; then
+        run_root() { sudo -A -- "$@"; }
+    else
+        run_root() { sudo -- "$@"; }
+    fi
+else
+    AM_ROOT=1
+    run_root() { "$@"; }
+fi
+
+# GitHub's runners create a $STORAGE/db.sql which contains the absolute storage path; that breaks
+# podman in the bootc-image-builder container. This is just a cache and can be removed safely
+if [ -z "$AM_ROOT" ] && [ -e "$STORAGE/db.sql" ]; then
+    mv "$STORAGE/db.sql" "$STORAGE/db.sql.bak"
+fi
+
+# image-builder requires --rootfs option for Fedora
+if echo "$OS_RELEASE" | grep -q '^ID=fedora'; then
+    ROOTFS_OPT="--rootfs=btrfs"
+fi
+
+# image-builder unfortunately needs $STORAGE to be writable, but that would destroy
+# permissions on the host; so mount it with a temp overlay
+run_root podman run --rm -i --privileged --security-opt=label=type:unconfined_t \
+    --volume="$STORAGE":/var/lib/containers/storage:O \
+    --volume=./tmp/bib.config.json:/config.json \
+    --volume="$OUTPUT":/output \
+    quay.io/centos-bootc/bootc-image-builder:latest \
+    --type=qcow2 ${ROOTFS_OPT:-} --config=/config.json \
+    "$OCI_TAG"
+
+# when running as user, restore permissions
+if [ -z "$AM_ROOT" ]; then
+    run_root chown -R "$(id -u):$(id -g)" "$OUTPUT"
+    if [ -e "$STORAGE/db.sql.bak" ]; then
+        mv "$STORAGE/db.sql.bak" "$STORAGE/db.sql"
+    fi
+fi

--- a/src/tox_lsr/test_scripts/runcontainer.sh
+++ b/src/tox_lsr/test_scripts/runcontainer.sh
@@ -369,7 +369,7 @@ run_playbooks() {
         run_podman "$test_pb_base"
         echo "sut ansible_host=$container_id ansible_connection=podman ansible_become=false" > "$inv_file"
         # reboot does not work in systemd containers, it just stops them
-        CONTAINER_SKIP_TAGS="${CONTAINER_SKIP_TAGS:-} --skip-tags tests::reboot"
+        CONTAINER_SKIP_TAGS="${CONTAINER_SKIP_TAGS:-} --skip-tags tests::reboot,tests::bootc-e2e"
     fi
 
     if [ -z "$container_id" ]; then
@@ -384,6 +384,7 @@ run_playbooks() {
             # shellcheck disable=SC2086
             ansible-playbook -vv ${CONTAINER_SKIP_TAGS:-} ${EXTRA_SKIP_TAGS:-} \
                 -i "$inv_file" ${vault_args:-} \
+                -e lsr_scriptdir="$LSR_SCRIPTDIR" \
                 -e ansible_playbook_filepath="$(type -p ansible-playbook)" "$pb"
         done
     else
@@ -391,6 +392,7 @@ run_playbooks() {
             # shellcheck disable=SC2086
             ansible-playbook -vv ${CONTAINER_SKIP_TAGS:-} ${EXTRA_SKIP_TAGS:-} \
                 -i "$inv_file" ${vault_args:-} \
+                -e lsr_scriptdir="$LSR_SCRIPTDIR" \
                 -e ansible_playbook_filepath="$(type -p ansible-playbook)" \
                 "$pb"
         done

--- a/src/tox_lsr/test_scripts/vault-sudo-askpass.sh
+++ b/src/tox_lsr/test_scripts/vault-sudo-askpass.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# `sudo -A` ($SUDO_ASKPASS) script that gets the value of `sudo_password` from
+# the vault, as described in ./README.md
+set -eu
+# we need the tail to strip off the "localhost | CHANGED .." summary
+ansible localhost -m command -a 'echo {{ sudo_password }}' -e '@vars/vault-variables.yml' --vault-password-file vault_pwd | tail -n1


### PR DESCRIPTION
`bootc-buildah-qcow.sh` will be used for end-to-end testing of bootc support. At the end of the setup phase, the test calls this script to turn the buildah container into a temporary podman image and invoke https://github.com/osbuild/bootc-image-builder to create a bootable qcow2 image out of it.

Unfortunately bootc-image-builder requires real root privileges. This script is usually never called as root, so add two privilege escalation mechanisms: simple `sudo` when running as user on real iron (also applies to GitHub actions), and `flatpak-spawn` → `sudo` when running in a toolbx container. To make this work when running in Ansible (no stdin/tty), provide a `$SUDO_ASKPASS` helper script that gets `sudo_password` from our vault, as described in README.md.

Update `runcontainer.sh` to export the tox script directory as variable, so that playbooks can run the script.

Some roles may chose to add exclusive bootc end-to-end tests. These need to be tagged with `tests::bootc-e2e`. Skip these during system container runs.

----

I tested this on my fork with three roles: [sudo](https://github.com/martinpitt/lsr-sudo/tree/qemu-bootc) ([PR with new test](https://github.com/linux-system-roles/sudo/pull/58), alternative [PR with modifying existing test](https://github.com/linux-system-roles/sudo/pull/59)), [firewall](https://github.com/martinpitt/lsr-firewall/tree/qemu-bootc) ([test run](https://github.com/martinpitt/lsr-firewall/actions/runs/15297581840)), and [postgresql](https://github.com/martinpitt/lsr-postgresql/tree/qemu-bootc) ([test run](https://github.com/martinpitt/lsr-postgresql/actions/runs/15298938487)). Postgresql actually [failed](https://github.com/martinpitt/lsr-postgresql/actions/runs/15298938487/job/43034539130#step:14:15), for a very good reason -- this needs fixing in the role, and is an actual bug in bootc mode. Yay for finding this! (The role auto-detects `shared_buffers` from the container build, and tries to apply it to the VM which has much less RAM).

## Summary by Sourcery

Add tooling and workflow updates to enable bootc end-to-end testing by converting Buildah containers into QCOW2 images with proper privilege escalation and integrating the new scripts into the test runner

New Features:
- Introduce bootc-buildah-qcow.sh to convert Buildah containers into bootable QCOW2 images for bootc end-to-end tests
- Add vault-sudo-askpass.sh helper to retrieve sudo_password from Ansible vault for non-interactive sudo

Enhancements:
- Update runcontainer.sh to export the test script directory and skip tests::bootc-e2e in system container runs

Documentation:
- Document encrypting sudo_password via stdin and running bootc end-to-end tests in README.md

Tests:
- Skip tests tagged tests::bootc-e2e during system container executions