### PR TITLE
support ansible-core 2.18, 2.19; add py313; drop py26

### DIFF
--- a/src/tox_lsr/config_files/tox-default.ini
+++ b/src/tox_lsr/config_files/tox-default.ini
@@ -2,7 +2,7 @@
 [tox]
 envlist =
     black, pylint, flake8, yamllint
-    py{26,27,36,38,39,310,311,312}, shellcheck
+    py{27,36,38,39,310,311,312,313}, shellcheck
     collection, ansible-lint
     ansible-test, woke, codeql
 skipsdist = true
@@ -32,10 +32,9 @@ setenv =
     LSR_TOX_ENV_TMP_DIR = {envtmpdir}
     LSR_SRC_OWNER = {env:LSR_SRC_OWNER:linux-system-roles}
 deps =
-    py{26,27,36,38,39,310,311,312}: pytest-cov
-    py{27,36,38,39,310,311,312}: pytest>=3.5.1
-    py26: pytest
-    py{26,27,36,38,39,310,311,312}: -rpytest_extra_requirements.txt
+    py{27,36,38,39,310,311,312,313}: pytest-cov
+    py{27,36,38,39,310,311,312,313}: pytest>=3.5.1
+    py{27,36,38,39,310,311,312,313}: -rpytest_extra_requirements.txt
 allowlist_externals =
     bash
     mkdir
@@ -64,13 +63,6 @@ commands =
 [lsr_pytest]
 configfile = {lsr_configdir}/pytest.ini
 
-[testenv:py26]
-install_command =
-    pip install --index-url=file:///local_pypi_index/simple {opts} {packages}
-list_dependencies_command =
-    pip freeze
-basepython = python2.6
-
 [testenv:py27]
 basepython = python2.7
 
@@ -91,6 +83,9 @@ basepython = python3.11
 
 [testenv:py312]
 basepython = python3.12
+
+[testenv:py313]
+basepython = python3.13
 
 [lsr_black]
 configfile = {lsr_configdir}/black.toml
@@ -116,7 +111,7 @@ basepython = python3
 passenv = RUN_PYLINT_*
 changedir = {toxinidir}
 deps =
-    {env:LSR_PYLINT_ANSIBLE_DEP:ansible-core==2.17.*}
+    {env:LSR_PYLINT_ANSIBLE_DEP:ansible-core==2.18.*}
     colorama
     pylint==3.1.0  # this is the version used by the latest ansible-test
     -rpylint_extra_requirements.txt
@@ -172,12 +167,6 @@ commands =
 [testenv:coveralls]
 deps =
     coveralls
-commands = {[coveralls]commands}
-
-[testenv:coveralls26]
-deps =
-    coverage==4.5.4
-    coveralls==1.11.1
 commands = {[coveralls]commands}
 
 # By default molecule will use docker as the driver - set the env. var.
@@ -274,7 +263,7 @@ commands =
 # ansible 2.10 seems better in this respect
 basepython = python3
 deps =
-    {env:LSR_ANSIBLE_TEST_DEP:ansible-core==2.17.*}
+    {env:LSR_ANSIBLE_TEST_DEP:ansible-core==2.18.*}
 commands =
     bash {lsr_scriptdir}/runansible-test.sh
 
@@ -391,6 +380,29 @@ deps =
 commands =
     {[qemu_common]commands}
 
+[testenv:qemu-ansible-core-2.18]
+changedir = {[qemu_common]changedir}
+basepython = {[qemu_common]basepython}
+setenv =
+    {[qemu_common]setenv}
+deps =
+    {[qemu_common]deps}
+    ansible-core==2.18.*
+commands =
+    {[qemu_common]commands}
+
+[testenv:qemu-ansible-core-2.19]
+changedir = {[qemu_common]changedir}
+basepython = {[qemu_common]basepython}
+pip_pre = true
+setenv =
+    {[qemu_common]setenv}
+deps =
+    {[qemu_common]deps}
+    ansible-core==2.19.*
+commands =
+    {[qemu_common]commands}
+
 [testenv:ansible-plugin-scan]
 changedir = {env:LSR_RUN_TEST_DIR:{toxinidir}}
 basepython = python3
@@ -499,6 +511,27 @@ setenv =
     {[container_common]setenv}
 deps =
     ansible-core==2.17.*
+commands =
+    {[container_common]commands}
+
+[testenv:container-ansible-core-2.18]
+changedir = {[container_common]changedir}
+basepython = {[container_common]basepython}
+setenv =
+    {[container_common]setenv}
+deps =
+    ansible-core==2.18.*
+commands =
+    {[container_common]commands}
+
+[testenv:container-ansible-core-2.19]
+changedir = {[container_common]changedir}
+basepython = {[container_common]basepython}
+pip_pre = true
+setenv =
+    {[container_common]setenv}
+deps =
+    ansible-core==2.19.*
 commands =
     {[container_common]commands}
 

--- a/tests/fixtures/test_tox_merge_ini/result.ini
+++ b/tests/fixtures/test_tox_merge_ini/result.ini
@@ -29,10 +29,9 @@ setenv = PYTHONPATH = {env:LSR_PYTHONPATH:}{toxinidir}/library:{toxinidir}/modul
 	LSR_SRC_OWNER = {env:LSR_SRC_OWNER:linux-system-roles}
 	LOCAL1 = local1
 	LOCAL2 = local2
-deps = py{26,27,36,38,39,310,311,312}: pytest-cov
-	py{27,36,38,39,310,311,312}: pytest>=3.5.1
-	py26: pytest
-	py{26,27,36,38,39,310,311,312}: -rpytest_extra_requirements.txt
+deps = py{27,36,38,39,310,311,312,313}: pytest-cov
+	py{27,36,38,39,310,311,312,313}: pytest>=3.5.1
+	py{27,36,38,39,310,311,312,313}: -rpytest_extra_requirements.txt
 	localdep1
 	localdep2
 allowlist_externals = bash
@@ -46,11 +45,6 @@ description = my local tox tests
 
 [lsr_pytest]
 configfile = {lsr_configdir}/pytest.ini
-
-[testenv:py26]
-install_command = pip install --index-url=file:///local_pypi_index/simple {opts} {packages}
-list_dependencies_command = pip freeze
-basepython = python2.6
 
 [testenv:py27]
 basepython = python2.7
@@ -73,6 +67,9 @@ basepython = python3.11
 [testenv:py312]
 basepython = python3.12
 
+[testenv:py313]
+basepython = python3.13
+
 [lsr_black]
 configfile = {lsr_configdir}/black.toml
 
@@ -94,7 +91,7 @@ configfile = {lsr_configdir}/pylintrc
 basepython = python3
 passenv = RUN_PYLINT_*
 changedir = {toxinidir}
-deps = {env:LSR_PYLINT_ANSIBLE_DEP:ansible-core==2.17.*}
+deps = {env:LSR_PYLINT_ANSIBLE_DEP:ansible-core==2.18.*}
 	colorama
 	pylint==3.1.0  # this is the version used by the latest ansible-test
 	-rpylint_extra_requirements.txt
@@ -144,11 +141,6 @@ commands = {[lsr_config]commands_pre}
 
 [testenv:coveralls]
 deps = coveralls
-commands = {[coveralls]commands}
-
-[testenv:coveralls26]
-deps = coverage==4.5.4
-	coveralls==1.11.1
 commands = {[coveralls]commands}
 
 [molecule_common]
@@ -218,7 +210,7 @@ commands = bash {lsr_scriptdir}/setup_module_utils.sh
 
 [testenv:ansible-test]
 basepython = python3
-deps = {env:LSR_ANSIBLE_TEST_DEP:ansible-core==2.17.*}
+deps = {env:LSR_ANSIBLE_TEST_DEP:ansible-core==2.18.*}
 commands = bash {lsr_scriptdir}/runansible-test.sh
 
 [testenv:woke]
@@ -305,6 +297,23 @@ deps = {[qemu_common]deps}
 	ansible-core==2.17.*
 commands = {[qemu_common]commands}
 
+[testenv:qemu-ansible-core-2.18]
+changedir = {[qemu_common]changedir}
+basepython = {[qemu_common]basepython}
+setenv = {[qemu_common]setenv}
+deps = {[qemu_common]deps}
+	ansible-core==2.18.*
+commands = {[qemu_common]commands}
+
+[testenv:qemu-ansible-core-2.19]
+changedir = {[qemu_common]changedir}
+basepython = {[qemu_common]basepython}
+pip_pre = true
+setenv = {[qemu_common]setenv}
+deps = {[qemu_common]deps}
+	ansible-core==2.19.*
+commands = {[qemu_common]commands}
+
 [testenv:ansible-plugin-scan]
 changedir = {env:LSR_RUN_TEST_DIR:{toxinidir}}
 basepython = python3
@@ -387,6 +396,21 @@ changedir = {[container_common]changedir}
 basepython = {[container_common]basepython}
 setenv = {[container_common]setenv}
 deps = ansible-core==2.17.*
+commands = {[container_common]commands}
+
+[testenv:container-ansible-core-2.18]
+changedir = {[container_common]changedir}
+basepython = {[container_common]basepython}
+setenv = {[container_common]setenv}
+deps = ansible-core==2.18.*
+commands = {[container_common]commands}
+
+[testenv:container-ansible-core-2.19]
+changedir = {[container_common]changedir}
+basepython = {[container_common]basepython}
+pip_pre = true
+setenv = {[container_common]setenv}
+deps = ansible-core==2.19.*
 commands = {[container_common]commands}
 
 [testenv:markdownlint]

--- a/tests/unit/test_hooks4.py
+++ b/tests/unit/test_hooks4.py
@@ -32,7 +32,7 @@ from .utils import (
 
 DEFAULT_INI = {
     "tox": {
-        "envlist": "py{26,27,36,37,38,39,310,311}, black, pylint, flake8",
+        "envlist": "py{27,36,37,38,39,310,311,312,313}, black, pylint, flake8",
         "skip_missing_interpreters": "true",
     },
     "testenv": {
@@ -61,7 +61,7 @@ TOX_INI_MISSING_TOX_SECTION = {
 }
 TOX_INI_MISSING_TOX_SECTION_MERGED = {
     "tox": {
-        "envlist": "py{26,27,36,37,38,39,310,311}, black, pylint, flake8",
+        "envlist": "py{27,36,37,38,39,310,311,312,313}, black, pylint, flake8",
         "skip_missing_interpreters": "true",
     },
     "testenv": {
@@ -103,7 +103,7 @@ TOX_INI_OVERRIDE_DEFAULTS = {
 }
 TOX_INI_OVERRIDE_DEFAULTS_MERGED = {
     "tox": {
-        "envlist": "py{26,27,36,37,38,39,310,311}, black, pylint, flake8",
+        "envlist": "py{27,36,37,38,39,310,311,312,313}, black, pylint, flake8",
         "skip_missing_interpreters": "false",
         "skipsdist": "true",
     },


### PR DESCRIPTION
ansible-core 2.18 is the latest stable version, so add support for it
and use it for ansible-test.

add support for ansible-core 2.19, which is pre-release, so need to
use the pip_pre flag to install it.

add support for python 3.13

remove python 2.6

## Summary by Sourcery

Add support for ansible-core 2.18 and experimental 2.19 in tox test environments, introduce Python 3.13, and drop legacy Python 2.6 support.

New Features:
- Add Python 3.13 test environment in tox configuration
- Enable installation of pre-release ansible-core 2.19 with pip_pre flag

Enhancements:
- Upgrade default ansible-core version from 2.17 to 2.18 across ansible-test, pylint, qemu, and container testenvs

Tests:
- Update test fixtures to reflect the revised envlist and dependency changes

Chores:
- Remove Python 2.6 and coveralls26 tox environments and related dependencies