### PR TITLE
doc: Image mode testing, container support tags, fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -764,6 +764,8 @@ ansible-vault encrypt_string --vault-password-file tests/vault_pwd \
   --stdin-name sudo_password >> tests/vars/vault-variables.yml
 ```
 
+Type the password and press Control-D.
+
 Do this to run bootc end-to-end tests which call
 [bootc-buildah-qcow.sh](./src/tox_lsr/test_scripts/bootc-buildah-qcow.sh),
 unless your system has passwordless sudo.

--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@ the tox-lsr repo.
 * `--image-name` - assuming you have a config file (`--config`) that maps the
   given image name to an image url and optional setup, you can just specify an
   image name like `--image-name centos-10` and the script will download the
-  latest qcow2 compose image for Fedora to a local cache (`--cache`).  The
+  latest qcow2 compose image for CentOS 10 to a local cache (`--cache`).  The
   script will check to see if the downloaded image in the cache is the latest,
   and will not download if not needed.  In the config file you can specify
   additional setup steps to be run e.g. setting up additional dnf/yum repos.
@@ -882,7 +882,7 @@ You must provide `--image-name`.
 * `--image-name` - assuming you have a config file (`--config`) that maps the
   given image name to a container registry image and optional setup, you can just specify an
   image name like `--image-name centos-10` and the script will pull the
-  latest image for Fedora 38.  In the config file you can specify
+  latest image for CentOS 10.  In the config file you can specify
   additional setup steps to be run e.g. setting up additional dnf/yum repos.
   The corresponding environment variable is `CONTAINER_IMAGE_NAME`.
 * `--config` - default `$HOME/.config/linux-system-roles.json` - this is the

--- a/README.md
+++ b/README.md
@@ -883,13 +883,18 @@ packages to build into the image.
 
 ### Container testing
 
-Integration tests can be run using containers.  `tox` will start one or
-more containers for the managed nodes using `podman` and the Ansible `podman` connection
-plugin.  There are some test envs that can be used to run these
-tests:
-* `container-ansible-2.9` - tests against Ansible 2.9
-  * also uses jinja 2.7 if supported by the python used
-* `container-ansible-core-2.x` - tests against ansible-core 2.x
+Integration tests can be run using containers. Some roles support it officially
+and run container tests in CI; these are tagged with `container` in
+meta/main.yml. If you are working on a role and notice that container tests
+work, or you are fixing them, please add that tag -- that will automatically
+enable the corresponding tests.
+
+`tox` will start one or more containers for the managed nodes using `podman`
+and the Ansible `podman` connection plugin.  There are some test envs that can
+be used to run these tests:
+* `container-ansible-2.9` - tests against Ansible 2.9 also uses jinja 2.7 if
+* supported by the python used `container-ansible-core-2.x` - tests against
+* ansible-core 2.x
 
 These tests run in one of two modes, depending on which of the following
 arguments you provide.  Note that you must use `--` on the command line after


### PR DESCRIPTION
Rendered views:
 - https://github.com/martinpitt/tox-lsr/tree/doc?tab=readme-ov-file#container-testing
 - https://github.com/martinpitt/tox-lsr/tree/doc?tab=readme-ov-file#image-mode-testing

## Summary by Sourcery

Update README to enhance and correct documentation for container-based and image mode testing workflows, expand configuration examples, and introduce tags for automated test enabling.

Bug Fixes:
- Corrected references from Fedora to CentOS 10 in image selection examples.

Enhancements:
- Clarified `--image-name` usage and switched the config code block to JSON with extended fields (source, variant, subvariant, container, openstack_image, upload_results).
- Expanded example config’s setup section to use a looped repository task with `yum_repository` module.
- Updated container testing instructions to describe `container` tags in meta/main.yml and refine test environment listings.
- Added a new “Image mode testing” section covering BootC image builds, `containerbuild` tag, buildah usage, and end-to-end QEMU validation.
- Inserted a prompt note for entering the sudo password (Control-D) after ansible-vault encryption.