### PR TITLE
runcontainer: Install test collection requirements

### DIFF
--- a/src/tox_lsr/test_scripts/runcontainer.sh
+++ b/src/tox_lsr/test_scripts/runcontainer.sh
@@ -66,7 +66,7 @@ install_requirements() {
         save_tar="$WORKDIR/save.tar"
         tar cfP "$save_tar" -C "$coll_path" "$LOCAL_COLLECTION"
     fi
-    for rq in meta/requirements.yml meta/collection-requirements.yml; do
+    for rq in meta/requirements.yml meta/collection-requirements.yml tests/collection-requirements.yml; do
         if [ -f "$rq" ]; then
             if [ "$rq" = meta/requirements.yml ]; then
                 warning use meta/collection-requirements.yml instead of "$rq"


### PR DESCRIPTION
Similar to what runqemy.py does. This fixes running the `nbde_client` role in containers.

---

Fixes [these failures](https://github.com/martinpitt/lsr-nbde_client/actions/runs/15847564326/job/44673167086):

```
TASK [Deploy NBDE server for testing] ******************************************
task path: /home/runner/work/lsr-nbde_client/lsr-nbde_client/tests/tasks/setup_test.yml:55
ERROR! the role 'fedora.linux_system_roles.nbde_server' was not found in /home/runner/work/lsr-nbde_client/lsr-nbde_client/tests/roles:/home/runner/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles:/home/runner/work/lsr-nbde_client/lsr-nbde_client/tests

The error appears to be in '/home/runner/work/lsr-nbde_client/lsr-nbde_client/tests/tasks/setup_test.yml': line 57, column 11, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

  include_role:
    name: fedora.linux_system_roles.nbde_server
          ^ here
```

## Summary by Sourcery

Include test collection requirements in the container setup to ensure ansible roles needed for nbde_client tests are installed

Bug Fixes:
- Resolve missing nbde_server role in containerized tests by installing test collection requirements

Enhancements:
- Extend runcontainer.sh to process tests/collection-requirements.yml alongside existing requirement files