### PR TITLE
ci: ansible-lint requires collection deps to be installed

### DIFF
--- a/src/tox_lsr/config_files/tox-default.ini
+++ b/src/tox_lsr/config_files/tox-default.ini
@@ -251,12 +251,13 @@ commands =
     {[lsr_config]commands_post}
 commands_post =
     bash {lsr_scriptdir}/ansible-lint-helper.sh post
-    # not sure why this creates the .ansible directory
-    bash -c 'rm -rf .ansible'
 
 [testenv:ansible-lint-collection]
 basepython = python3
 changedir = {toxworkdir}/ansible_collections/{env:LSR_ROLE2COLL_NAMESPACE}/{env:LSR_ROLE2COLL_NAME}
+setenv =
+    {[testenv]setenv}
+    ANSIBLE_COLLECTIONS_PATH = {toxworkdir}
 allowlist_externals =
     bash
     cp
@@ -272,8 +273,6 @@ commands =
     {[lsr_config]commands_post}
 commands_post =
     bash {lsr_scriptdir}/ansible-lint-helper.sh post
-    # not sure why this creates the .ansible directory
-    bash -c 'rm -rf .ansible'
 
 [testenv:ansible-test]
 # NOTE: ansible-test in ansible 2.9 seems to become confused

--- a/src/tox_lsr/test_scripts/ansible-lint-helper.sh
+++ b/src/tox_lsr/test_scripts/ansible-lint-helper.sh
@@ -38,9 +38,25 @@ pre() {
         done
         popd
     fi
+    # install collection requirements - filter out $LSR_ROLE2COLL_NAMESPACE.$LSR_ROLE2COLL_NAME
+    reqs="$LSR_TOX_ENV_TMP_DIR/collection-requirements.yml"
+    rm -f "$reqs"
+    yq eval-all "
+    . as \$item ireduce ([]; . + (\$item.collections // []))
+    | map(select(.name != \"$LSR_ROLE2COLL_NAMESPACE.$LSR_ROLE2COLL_NAME\"))
+    | {\"collections\": .}
+    " \
+    <([[ -f "$TOXINIDIR/meta/collection-requirements.yml" ]] && cat "$TOXINIDIR/meta/collection-requirements.yml" || printf "collections: []\n") \
+    <([[ -f "$TOXINIDIR/tests/collection-requirements.yml" ]] && cat "$TOXINIDIR/tests/collection-requirements.yml" || printf "collections: []\n") \
+    > "$reqs"
+    if [ -f "$reqs" ]; then
+        echo "Installing collection requirements for ansible-lint from $reqs"
+        ansible-galaxy collection install -vv -p "$TOX_WORK_DIR" --force -r "$reqs"
+    fi
 }
 
 post() {
+    rm -rf .ansible
     if [ -f "$mm_bkup" ]; then
         mv "$mm_bkup" "$mm"
     fi

--- a/tests/fixtures/test_tox_merge_ini/result.ini
+++ b/tests/fixtures/test_tox_merge_ini/result.ini
@@ -202,11 +202,12 @@ commands = bash {lsr_scriptdir}/setup_module_utils.sh
 	ansible-lint {env:RUN_ANSIBLE_LINT_EXTRA_ARGS:} {posargs}
 	{[lsr_config]commands_post}
 commands_post = bash {lsr_scriptdir}/ansible-lint-helper.sh post
-	bash -c 'rm -rf .ansible'
 
 [testenv:ansible-lint-collection]
 basepython = python3
 changedir = {toxworkdir}/ansible_collections/{env:LSR_ROLE2COLL_NAMESPACE}/{env:LSR_ROLE2COLL_NAME}
+setenv = {[testenv]setenv}
+	ANSIBLE_COLLECTIONS_PATH = {toxworkdir}
 allowlist_externals = bash
 	cp
 deps = {env:LSR_ANSIBLE_LINT_DEP:ansible-lint}
@@ -217,7 +218,6 @@ commands = bash {lsr_scriptdir}/setup_module_utils.sh
 	ansible-lint {env:RUN_ANSIBLE_LINT_EXTRA_ARGS:} {posargs}
 	{[lsr_config]commands_post}
 commands_post = bash {lsr_scriptdir}/ansible-lint-helper.sh post
-	bash -c 'rm -rf .ansible'
 
 [testenv:ansible-test]
 basepython = python3


### PR DESCRIPTION
ansible-lint requires collection deps to be installed

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Install required Ansible collections for ansible-lint runs and simplify cleanup handling in the lint helper and tox configuration.

New Features:
- Automatically install Ansible collection requirements for ansible-lint based on role and test collection-requirements files.

Enhancements:
- Configure ansible-lint collection tox environment to use the tox work directory as ANSIBLE_COLLECTIONS_PATH.
- Centralize removal of the .ansible directory in the ansible-lint helper post step instead of duplicating cleanup commands in tox configs.

Tests:
- Update tox merge fixture to reflect new ansible-lint collection environment settings and centralized .ansible cleanup.