### PR TITLE
support ansible-core 2.21; lock ansible.posix to 2.1.X

### DIFF
--- a/src/tox_lsr/config_files/tox-default.ini
+++ b/src/tox_lsr/config_files/tox-default.ini
@@ -31,6 +31,7 @@ setenv =
     LSR_ROLE2COLL_NAME = linux_system_roles
     LSR_TOX_ENV_TMP_DIR = {envtmpdir}
     LSR_SRC_OWNER = {env:LSR_SRC_OWNER:linux-system-roles}
+    LSR_ANSIBLE_POSIX_VERSION = {env:LSR_ANSIBLE_POSIX_VERSION:ansible.posix>=2.1.0,<2.2.0}
 deps =
     py{27,36,38,39,310,311,312,313,314}: pytest-cov
     py{27,36,38,39,310,311,312,313,314}: pytest>=3.5.1
@@ -528,12 +529,22 @@ commands =
 [testenv:qemu-ansible-core-2-20]
 changedir = {[qemu_common]changedir}
 basepython = {[qemu_common]basepython}
-pip_pre = true
 setenv =
     {[qemu_common]setenv}
 deps =
     {[qemu_common]deps}
     ansible-core==2.20.*
+commands =
+    {[qemu_common]commands}
+
+[testenv:qemu-ansible-core-2-21]
+changedir = {[qemu_common]changedir}
+basepython = {[qemu_common]basepython}
+setenv =
+    {[qemu_common]setenv}
+deps =
+    {[qemu_common]deps}
+    ansible-core==2.21.*
 commands =
     {[qemu_common]commands}
 
@@ -671,11 +682,20 @@ commands =
 [testenv:container-ansible-core-2-20]
 changedir = {[container_common]changedir}
 basepython = {[container_common]basepython}
-pip_pre = true
 setenv =
     {[container_common]setenv}
 deps =
     ansible-core==2.20.*
+commands =
+    {[container_common]commands}
+
+[testenv:container-ansible-core-2-21]
+changedir = {[container_common]changedir}
+basepython = {[container_common]basepython}
+setenv =
+    {[container_common]setenv}
+deps =
+    ansible-core==2.21.*
 commands =
     {[container_common]commands}
 

--- a/src/tox_lsr/test_scripts/runcontainer.sh
+++ b/src/tox_lsr/test_scripts/runcontainer.sh
@@ -126,7 +126,7 @@ setup_callback_plugins() {
         fi
         if [ -n "${need_debug_py:-}" ] || [ -n "${need_profile_py:-}" ]; then
             info installing callback plugins in "$callback_plugin_dir"
-            galaxy_collection "$LSR_TOX_ENV_TMP_DIR" install -vv ansible.posix
+            galaxy_collection "$LSR_TOX_ENV_TMP_DIR" install -vv "${LSR_ANSIBLE_POSIX_VERSION:-ansible.posix}"
             tmp_debug_py="$LSR_TOX_ENV_TMP_DIR/ansible_collections/ansible/posix/plugins/callback/debug.py"
             tmp_profile_py="$LSR_TOX_ENV_TMP_DIR/ansible_collections/ansible/posix/plugins/callback/profile_tasks.py"
             if [ -n "${need_debug_py:-}" ]; then

--- a/src/tox_lsr/test_scripts/runqemu.py
+++ b/src/tox_lsr/test_scripts/runqemu.py
@@ -1399,7 +1399,7 @@ def setup_callback_plugins(pretty, profile, profile_task_limit, test_env):
                 os.environ["LSR_TOX_ENV_TMP_DIR"],
                 "-vv",
                 get_galaxy_force_flag(),
-                "ansible.posix",
+                os.environ.get("LSR_ANSIBLE_POSIX_VERSION", "ansible.posix"),
             ],
             stdout=sys.stdout,
             stderr=sys.stderr,

--- a/tests/fixtures/test_tox_merge_ini/result.ini
+++ b/tests/fixtures/test_tox_merge_ini/result.ini
@@ -27,6 +27,7 @@ setenv = PYTHONPATH = {env:LSR_PYTHONPATH:}{toxinidir}/library:{toxinidir}/modul
 	LSR_ROLE2COLL_NAME = linux_system_roles
 	LSR_TOX_ENV_TMP_DIR = {envtmpdir}
 	LSR_SRC_OWNER = {env:LSR_SRC_OWNER:linux-system-roles}
+	LSR_ANSIBLE_POSIX_VERSION = {env:LSR_ANSIBLE_POSIX_VERSION:ansible.posix>=2.1.0,<2.2.0}
 	LOCAL1 = local1
 	LOCAL2 = local2
 deps = py{27,36,38,39,310,311,312,313,314}: pytest-cov
@@ -403,10 +404,17 @@ commands = {[qemu_common]commands}
 [testenv:qemu-ansible-core-2-20]
 changedir = {[qemu_common]changedir}
 basepython = {[qemu_common]basepython}
-pip_pre = true
 setenv = {[qemu_common]setenv}
 deps = {[qemu_common]deps}
 	ansible-core==2.20.*
+commands = {[qemu_common]commands}
+
+[testenv:qemu-ansible-core-2-21]
+changedir = {[qemu_common]changedir}
+basepython = {[qemu_common]basepython}
+setenv = {[qemu_common]setenv}
+deps = {[qemu_common]deps}
+	ansible-core==2.21.*
 commands = {[qemu_common]commands}
 
 [testenv:ansible-plugin-scan]
@@ -510,9 +518,15 @@ commands = {[container_common]commands}
 [testenv:container-ansible-core-2-20]
 changedir = {[container_common]changedir}
 basepython = {[container_common]basepython}
-pip_pre = true
 setenv = {[container_common]setenv}
 deps = ansible-core==2.20.*
+commands = {[container_common]commands}
+
+[testenv:container-ansible-core-2-21]
+changedir = {[container_common]changedir}
+basepython = {[container_common]basepython}
+setenv = {[container_common]setenv}
+deps = ansible-core==2.21.*
 commands = {[container_common]commands}
 
 [testenv:markdownlint]


### PR DESCRIPTION
Add support for ansible-core 2.21

lock ansible.posix to version 2.1.X

Signed-off-by: Rich Megginson <rmeggins@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Ansible Core 2.21 with dedicated QEMU and container test environments
  * Ansible.posix collection version is now configurable via environment variable with default version constraint

* **Improvements**
  * Simplified Ansible Core 2.20 environment configuration by removing unnecessary settings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linux-system-roles/tox-lsr/pull/242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->