### PR TITLE
ci: use commit hash for github action, add persist-credentials false [citest_skip]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/tox-py36.yml
+++ b/.github/workflows/tox-py36.yml
@@ -12,7 +12,9 @@ jobs:
         run: dnf install -y git-core python3-pip
 
       - name: checkout PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install platform dependencies, python, tox
         run: |

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -25,7 +25,9 @@ jobs:
     runs-on: ${{ matrix.pyver_os.os }}
     steps:
       - name: checkout PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up Python 2.7
         if: ${{ matrix.pyver_os.ver == '2.7' }}
         run: |
@@ -34,7 +36,7 @@ jobs:
           sudo apt install -y python2.7
       - name: Set up Python 3
         if: ${{ matrix.pyver_os.ver != '2.7' }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.pyver_os.ver }}
       - name: Install platform dependencies, python, tox


### PR DESCRIPTION
The latest security guidance is to use the full commit hash, which is immutable,
instead of a tag or version, which can be mutable, for the reference to a version
of a github action.  There are known attacks which inserted unauthorized code
in a version tag and moved the tag.  This prevents this sort of attack, at the
cost of more maintenance burden, but dependabot will largely take care of this
for us.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated monthly updates for GitHub Actions dependencies.
  * Improved the reliability and reproducibility of automated testing workflows by pinning action versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->